### PR TITLE
Peg ffi to version 1.9.21 for https://github.com/ffi/ffi/issues/640

### DIFF
--- a/stash_discovery/stash_discovery.gemspec
+++ b/stash_discovery/stash_discovery.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_dependency 'blacklight', '~> 6.5.0'
   s.add_dependency 'config'
+  s.add_dependency 'ffi', '1.9.21' # peg to 1.9.21 for https://github.com/ffi/ffi/issues/640
   s.add_dependency 'geoblacklight', '~> 1.1.2'
   s.add_dependency 'jquery-rails', '~> 4.1'
   s.add_dependency 'rails', '~> 4.2'


### PR DESCRIPTION
Deals with an [issue](https://github.com/ffi/ffi/issues/640) where native extensions of recent versions of the [ffi](https://github.com/ffi/ffi) gem (a transitive dependency of Geoblacklight) won't build on macOS by explicitly requiring the gem and pegging it at a specific version that's known to build.

We should be able to remove this line from the Gemspec once ffi's issue is fixed.