### PR TITLE
Even unverified emails will get populated in DB table if Dryad exposes them for a user after they log in

### DIFF
--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -90,7 +90,7 @@ module StashEngine
       resp = RestClient.get "#{StashEngine.app.orcid.api}/v2.1/#{orcid}/email",
                             'Content-type' => 'application/vnd.orcid+json', 'Authorization' => "Bearer #{bearer_token}"
       my_info = JSON.parse(resp.body)
-      my_info['email'].map { |item| (item['verified'] ? item['email'] : nil) }.compact
+      my_info['email'].map { |item| ( item['email'].blank? ? nil : item['email'] ) }.compact
     rescue RestClient::Exception => e
       logger.error(e)
       return []

--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -90,7 +90,7 @@ module StashEngine
       resp = RestClient.get "#{StashEngine.app.orcid.api}/v2.1/#{orcid}/email",
                             'Content-type' => 'application/vnd.orcid+json', 'Authorization' => "Bearer #{bearer_token}"
       my_info = JSON.parse(resp.body)
-      my_info['email'].map { |item| ( item['email'].blank? ? nil : item['email'] ) }.compact
+      my_info['email'].map { |item| (item['email'].blank? ? nil : item['email']) }.compact
     rescue RestClient::Exception => e
       logger.error(e)
       return []


### PR DESCRIPTION
https://github.com/CDL-Dryad/dryad-product-roadmap/issues/30

Adding the email if unverified and we can get it.  I also made some changes to the user model and use of email as a local variable since email is also an activerecord field so may cause problems or confusion.

I tested this with a new orcid sandbox account after setting the email to partner (and unverified) and it worked for me.