### PR TITLE
Shibboleth set tenant

### DIFF
--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -9,6 +9,8 @@ module StashEngine
 
     # this is the place omniauth calls back for shibboleth/google logins
     def callback
+      logger.debug("tenant_id: #{params[:tenant_id]}")
+      logger.debug("params: #{params}")
       current_user.update(tenant_id: params[:tenant_id])
       redirect_to dashboard_path
     end

--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -9,8 +9,6 @@ module StashEngine
 
     # this is the place omniauth calls back for shibboleth/google logins
     def callback
-      logger.debug("shibboleth callback: #{current_user.inspect}")
-      logger.debug("session user_id: #{session[:user_id]}")
       current_user.update(tenant_id: params[:tenant_id])
       redirect_to dashboard_path
     end
@@ -36,9 +34,7 @@ module StashEngine
 
     def choose_login; end
 
-    def choose_sso
-      logger.debug(current_user.inspect)
-    end
+    def choose_sso; end
 
     # no partner, so set as generic dryad tenant without membership benefits
     def no_partner
@@ -51,7 +47,6 @@ module StashEngine
 
     def callback_basics
       @auth_hash = request.env['omniauth.auth']
-      reset_session
       head(:forbidden) unless auth_hash_good
     end
 

--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -9,8 +9,6 @@ module StashEngine
 
     # this is the place omniauth calls back for shibboleth/google logins
     def callback
-      logger.debug("tenant_id: #{params[:tenant_id]}")
-      logger.debug("params: #{params}")
       current_user.update(tenant_id: params[:tenant_id])
       redirect_to dashboard_path
     end

--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -2,13 +2,14 @@ require_dependency 'stash_engine/application_controller'
 
 module StashEngine
   class SessionsController < ApplicationController # rubocop:disable Metrics/ClassLength
+    before_action :require_login, only: %i[callback]
     skip_before_action :verify_authenticity_token, only: %i[callback orcid_callback] # omniauth takes care of this differently
     before_action :callback_basics, only: %i[callback]
     before_action :orcid_preprocessor, only: [:orcid_callback] # do not go to main action if it's just a metadata set, not a login
 
     # this is the place omniauth calls back for shibboleth/google logins
     def callback
-      session[:user_id] = User.from_omniauth(@auth_hash, current_tenant.tenant_id, unmangle_orcid).id
+      current_user.update(tenant_id: params[:tenant_id])
       redirect_to dashboard_path
     end
 

--- a/stash_engine/app/controllers/stash_engine/sessions_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/sessions_controller.rb
@@ -9,6 +9,8 @@ module StashEngine
 
     # this is the place omniauth calls back for shibboleth/google logins
     def callback
+      logger.debug("shibboleth callback: #{current_user.inspect}")
+      logger.debug("session user_id: #{session[:user_id]}")
       current_user.update(tenant_id: params[:tenant_id])
       redirect_to dashboard_path
     end
@@ -34,7 +36,9 @@ module StashEngine
 
     def choose_login; end
 
-    def choose_sso; end
+    def choose_sso
+      logger.debug(current_user.inspect)
+    end
 
     # no partner, so set as generic dryad tenant without membership benefits
     def no_partner

--- a/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -12,7 +12,7 @@ module StashEngine
     def require_login
       return if current_user
       flash[:alert] = 'You must be logged in.'
-      redirect_to current_tenant.try(:omniauth_login_path)
+      redirect_to stash_url_helpers.choose_login_path
     end
 
     # this requires a method called resource in the controller that returns the current resource (usually @resource)

--- a/stash_engine/app/models/stash_engine/tenant.rb
+++ b/stash_engine/app/models/stash_engine/tenant.rb
@@ -54,7 +54,7 @@ module StashEngine
       extra_params = (params ? "?#{params.to_param}" : '')
       "https://#{full_domain}/Shibboleth.sso/Login?" \
           "target=#{CGI.escape("#{callback_path_begin}shibboleth/callback#{extra_params}")}" \
-          "&entityID=#{CGI.escape(authentication.entity_id)}&tenant_id=#{CGI.escape(tenant_id)}"
+          "&entityID=#{CGI.escape(authentication.entity_id)}"
     end
 
     def google_login_path(params = nil)

--- a/stash_engine/app/views/stash_engine/sessions/choose_sso.html.erb
+++ b/stash_engine/app/views/stash_engine/sessions/choose_sso.html.erb
@@ -11,7 +11,7 @@
   <% tenants.each_slice((tenants.count / 3.0).ceil).to_a.each do |tenant_column| %>
     <div class="c-institution__column">
       <% tenant_column.each do |t| %>
-        <%= link_to t.short_name, t.omniauth_login_path %><br/>
+        <%= link_to t.short_name, t.omniauth_login_path({tenant_id: t.tenant_id}) %><br/>
       <% end %>
     </div>
   <% end %>

--- a/stash_engine/spec/unit/models/tenant_spec.rb
+++ b/stash_engine/spec/unit/models/tenant_spec.rb
@@ -91,7 +91,7 @@ module StashEngine
         tenant = Tenant.by_domain('example.edu')
         login_path = tenant.omniauth_login_path
         # TODO: don't hard-code this
-        expect(login_path).to eq('https://stash-dev.example.edu/Shibboleth.sso/Login?target=https%3A%2F%2Fstash-dev.example.edu%2Fstash%2Fauth%2Fshibboleth%2Fcallback&entityID=urn%3Amace%3Aincommon%3Aexample.edu&tenant_id=exemplia')
+        expect(login_path).to eq('https://stash-dev.example.edu/Shibboleth.sso/Login?target=https%3A%2F%2Fstash-dev.example.edu%2Fstash%2Fauth%2Fshibboleth%2Fcallback&entityID=urn%3Amace%3Aincommon%3Aexample.edu')
       end
     end
 
@@ -121,7 +121,7 @@ module StashEngine
       it 'returns the login path' do
         tenant = Tenant.by_domain('example.edu')
         login_path = tenant.shibboleth_login_path
-        expect(login_path).to eq('https://stash-dev.example.edu/Shibboleth.sso/Login?target=https%3A%2F%2Fstash-dev.example.edu%2Fstash%2Fauth%2Fshibboleth%2Fcallback&entityID=urn%3Amace%3Aincommon%3Aexample.edu&tenant_id=exemplia')
+        expect(login_path).to eq('https://stash-dev.example.edu/Shibboleth.sso/Login?target=https%3A%2F%2Fstash-dev.example.edu%2Fstash%2Fauth%2Fshibboleth%2Fcallback&entityID=urn%3Amace%3Aincommon%3Aexample.edu')
       end
     end
 


### PR DESCRIPTION
This allows shibboleth login and is currently deployed on dryad-dev.cdlib.org.

Testing:
- delete your user record from the database
- log in
- select ucop
- log in by shib
- land on your datasets page
- check database for your user record.  You should see it is set to ucop if you logged in by shibboleth ucop.