### PR TITLE
Migrate mailer

### DIFF
--- a/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
@@ -16,15 +16,15 @@ module StashEngine
       current_user.old_dryad_email = params[:email]
       current_user.set_migration_token
       current_user.save
-      StashEngine::MigrationMailer.migration_email(email: current_user.old_dryad_email, code: current_user.migration_token, url: auth_migrate_code_url).deliver_now
+      StashEngine::MigrationMailer.migration_email(email: current_user.old_dryad_email,
+                                                   code: current_user.migration_token,
+                                                   url: auth_migrate_code_url).deliver_now
     end
 
     def migrate_data
-      unless User.find_by_migration_token(params[:code]).nil?
-        if User.find_by_migration_token(params[:code]).id == current_user.id
-          render 'stash_engine/dashboard/migrate_successful'
-        end
-      end
+      return unless User.find_by_migration_token(params[:code])
+      return unless User.find_by_migration_token(params[:code]).id == current_user.id
+      render 'stash_engine/dashboard/migrate_successful'
     end
 
     def migrate_successful; end

--- a/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
@@ -12,6 +12,23 @@ module StashEngine
 
     def upload_basics; end
 
+    def migrate_data_mail
+      current_user.old_dryad_email = params[:email]
+      current_user.set_migration_token
+      current_user.save
+      StashEngine::MigrationMailer.migration_email(email: current_user.old_dryad_email, code: current_user.migration_token).deliver_now
+    end
+
+    def migrate_data
+      unless User.find_by_migration_token(params[:code]).nil?
+        if User.find_by_migration_token(params[:code]).id == current_user.id
+          render 'stash_engine/dashboard/migrate_successful'
+        end
+      end
+    end
+
+    def migrate_successful; end
+
     # an AJAX wait to allow in-progress items to complete before continuing.
     def ajax_wait
       respond_to do |format|

--- a/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
@@ -16,7 +16,7 @@ module StashEngine
       current_user.old_dryad_email = params[:email]
       current_user.set_migration_token
       current_user.save
-      StashEngine::MigrationMailer.migration_email(email: current_user.old_dryad_email, code: current_user.migration_token).deliver_now
+      StashEngine::MigrationMailer.migration_email(email: current_user.old_dryad_email, code: current_user.migration_token, url: auth_migrate_code_url).deliver_now
     end
 
     def migrate_data

--- a/stash_engine/app/mailers/stash_engine/migration_mailer.rb
+++ b/stash_engine/app/mailers/stash_engine/migration_mailer.rb
@@ -1,0 +1,11 @@
+module StashEngine
+  class MigrationMailer < ApplicationMailer
+    default from: 'help@datadryad.org'
+    def migration_email(user)
+      @email = user[:email]
+      @code = user[:code]
+      @url = "test test"
+      mail(to: @email)
+    end
+  end
+end

--- a/stash_engine/app/mailers/stash_engine/migration_mailer.rb
+++ b/stash_engine/app/mailers/stash_engine/migration_mailer.rb
@@ -4,7 +4,7 @@ module StashEngine
     def migration_email(user)
       @email = user[:email]
       @code = user[:code]
-      @url = "test test"
+      @url = user[:url]
       mail(to: @email)
     end
   end

--- a/stash_engine/app/models/stash_engine/user.rb
+++ b/stash_engine/app/models/stash_engine/user.rb
@@ -2,6 +2,8 @@ module StashEngine
   class User < ActiveRecord::Base
     has_many :resources
 
+    after_find :set_migration_token
+
     def self.from_omniauth_orcid(auth_hash:, emails:)
       users = find_by_orcid_or_emails(orcid: auth_hash[:uid], emails: emails)
       raise 'More than one user matches the ID or email returned by ORCID' if users.count > 1
@@ -23,6 +25,25 @@ module StashEngine
 
     def superuser?
       role == 'superuser'
+    end
+
+    def set_migration_token
+      if self.migration_token.nil?
+        i = generate_migration_token
+        unless User.find_by(migration_token: i).nil?
+          i = generate_migration_token
+        end
+        self.migration_token = i
+        self.save
+      end
+    end
+
+    def generate_migration_token
+      i = ""
+      6.times do
+        i += "%d" % rand(10)
+      end
+      i
     end
 
     def self.split_name(name)

--- a/stash_engine/app/models/stash_engine/user.rb
+++ b/stash_engine/app/models/stash_engine/user.rb
@@ -28,20 +28,17 @@ module StashEngine
     end
 
     def set_migration_token
-      if self.migration_token.nil?
-        i = generate_migration_token
-        unless User.find_by(migration_token: i).nil?
-          i = generate_migration_token
-        end
-        self.migration_token = i
-        self.save
-      end
+      return unless migration_token.nil?
+      i = generate_migration_token
+      i = generate_migration_token while User.find_by(migration_token: i)
+      self.migration_token = i
+      save
     end
 
     def generate_migration_token
-      i = ""
+      i = ''
       6.times do
-        i += "%d" % rand(10)
+        i += format('%d', rand(10))
       end
       i
     end

--- a/stash_engine/app/views/stash_engine/dashboard/migrate_data.html.erb
+++ b/stash_engine/app/views/stash_engine/dashboard/migrate_data.html.erb
@@ -1,0 +1,15 @@
+<h1>Migrate Your Data</h1>
+<div>To migrate your data from your old DASH or Dryad account, please enter the email address you used for that account.
+  An email containing a six-digit code will be sent within five minutes.</div>
+<%= form_tag(auth_migrate_mail_path, method: "get") do %>
+  <%= label_tag(:email, "Email address:") %>
+  <%= text_field_tag(:email) %>
+  <%= submit_tag("Send code") %>
+<% end %>
+
+<div>Please enter the six-digit code from your email message to migrate your data.</div>
+<%= form_tag(auth_migrate_code_path, method: "get") do %>
+  <%= label_tag(:code, "Enter code:") %>
+  <%= text_field_tag(:code) %>
+  <%= submit_tag("Migrate data") %>
+<% end %>

--- a/stash_engine/app/views/stash_engine/dashboard/migrate_data_mail.html.erb
+++ b/stash_engine/app/views/stash_engine/dashboard/migrate_data_mail.html.erb
@@ -1,0 +1,7 @@
+<h1>Migrate Your Data</h1>
+<div>Please enter the six-digit code from your email message to migrate your data.</div>
+<%= form_tag(auth_migrate_code_path, method: "get") do %>
+  <%= label_tag(:code, "Enter code:") %>
+  <%= text_field_tag(:code) %>
+  <%= submit_tag("Migrate data") %>
+<% end %>

--- a/stash_engine/app/views/stash_engine/dashboard/migrate_successful.html.erb
+++ b/stash_engine/app/views/stash_engine/dashboard/migrate_successful.html.erb
@@ -1,0 +1,2 @@
+<h1>Migrate Your Data</h1>
+<div>Thank you. Your old Dryad data packages and submissions have now been connected to your current Dryad account.</div>

--- a/stash_engine/app/views/stash_engine/dashboard/show.html.erb
+++ b/stash_engine/app/views/stash_engine/dashboard/show.html.erb
@@ -12,6 +12,10 @@
 
 <div class="c-datasets-heading">
 	<h1 class="c-datasets-heading__heading o-heading__level1">My Datasets</h1>
+	<div>
+		Are you missing data from your old Dryad or DASH account?
+		<%= button_to 'Yes. Migrate my data.', auth_migrate_code_path, method: :get %>
+	</div>
 	<%= button_to 'Start New Dataset', new_resource_path, class: 'c-datasets-heading__button', form_class: 'o-button__inline-form', method: :get %>
 </div>
 

--- a/stash_engine/app/views/stash_engine/migration_mailer/migration_email.text.erb
+++ b/stash_engine/app/views/stash_engine/migration_mailer/migration_email.text.erb
@@ -1,0 +1,6 @@
+Welcome to the new Dryad Digital Repository, <%= @user %>
+===============================================
+
+To migrate your old packages to your new dashboard, please go to <%= @url %> and enter the following code: <%= @code %>.
+
+Thanks for joining and have a great day!

--- a/stash_engine/app/views/stash_engine/migration_mailer/migration_email.text.erb
+++ b/stash_engine/app/views/stash_engine/migration_mailer/migration_email.text.erb
@@ -1,4 +1,4 @@
-Welcome to the new Dryad Digital Repository, <%= @user %>
+Welcome to the new Dryad Digital Repository, <%= @email %>
 ===============================================
 
 To migrate your old packages to your new dashboard, please go to <%= @url %> and enter the following code: <%= @code %>.

--- a/stash_engine/config/routes.rb
+++ b/stash_engine/config/routes.rb
@@ -56,6 +56,9 @@ StashEngine::Engine.routes.draw do
   match 'auth/orcid/callback', :to => 'sessions#orcid_callback', :via => [:get, :post]
   match 'auth/developer/callback', to: 'sessions#developer_callback', :via => [:get, :post]
   match 'auth/:provider/callback', :to => 'sessions#callback', :via => [:get, :post]
+  match 'auth/migrate/mail', :to => 'dashboard#migrate_data_mail', :via => [:get]
+  match 'auth/migrate/code', :to => 'dashboard#migrate_data', :via => [:get]
+
   get 'auth/failure', :to => redirect('/')
   get 'sessions/destroy', :to => 'sessions#destroy'
   get 'sessions/choose_login', to: 'sessions#choose_login', as: 'choose_login'

--- a/stash_engine/db/migrate/20180718223728_add_migration_token.rb
+++ b/stash_engine/db/migrate/20180718223728_add_migration_token.rb
@@ -1,0 +1,6 @@
+class AddMigrationToken < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_users, :migration_token, :string
+    add_column :stash_engine_users, :old_dryad_email, :string
+  end
+end

--- a/stash_engine/test/mailers/previews/stash_engine/migration_preview.rb
+++ b/stash_engine/test/mailers/previews/stash_engine/migration_preview.rb
@@ -1,0 +1,6 @@
+module StashEngine
+  # Preview all emails at http://localhost:3000/rails/mailers/migration
+  class MigrationPreview < ActionMailer::Preview
+
+  end
+end

--- a/stash_engine/test/mailers/stash_engine/migration_test.rb
+++ b/stash_engine/test/mailers/stash_engine/migration_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+module StashEngine
+  class MigrationTest < ActionMailer::TestCase
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
Creates the ability to connect (in theory) old Dryad accounts, keyed on email addresses, to new Dryad accounts.

If someone enters this workflow from their dashboard, they will be offered the ability to enter an email associated with an old Dryad account. Currently, this is not verified to be attached to an old Dryad account in any way: it merely generates a token that is sent to that email address, so that we can verify that this user can access that email address.

To test: from the user dashboard, click on the “Migrate my data” button. You should be able to enter in an email address, obtain the token, and enter that token in on the following page. If you enter it incorrectly, you’ll go back to the first page in the path. This probably will need to be tweaked for real deployment, with mistake text and whatnot, but it works for now.