### PR TITLE
Include all *dash.datadryad.org servers in the exclusion

### DIFF
--- a/stash_engine/config/initializers/omniauth.rb
+++ b/stash_engine/config/initializers/omniauth.rb
@@ -28,7 +28,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   OmniAuth.config.full_host = -> (env) do
     # "omniauth.strategy"=>#<OmniAuth::Strategies::ORCID> might be helpful if we need to know if strategy is ORCID
     u = URI.parse("http://#{env['HTTP_X_FORWARDED_HOST'] || env['HTTP_HOST']}")
-    u.scheme = 'https' if env['omniauth.strategy'].to_s.include?('ORCID') && !u.host[/(localhost)|(daisiedash\.datadryad\.org)|(ryandash\.datadryad\.org)/]
+    u.scheme = 'https' if env['omniauth.strategy'].to_s.include?('ORCID') && !u.host[/(localhost)|(.+dash\.datadryad\.org)/]
     "#{u.scheme}://#{u.host}#{(u.port == 80 ? '' : ":#{u.port}" )}" # only add port if it's not 80
   end
 


### PR DESCRIPTION
This gives us one fix that allows any dev to add a VM if they use a hostname in this style.