### PR TITLE
Doorkeeper security updates, though we aren't using implicit grant

### DIFF
--- a/stash_api/Gemfile.lock
+++ b/stash_api/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
-    doorkeeper (4.3.1)
+    doorkeeper (4.4.2)
       railties (>= 4.2)
     erubis (2.7.0)
     globalid (0.4.1)
@@ -71,7 +71,7 @@ GEM
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rack (1.6.9)
@@ -153,4 +153,4 @@ DEPENDENCIES
   stash_api!
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/stash_api/db/migrate/20180822222838_add_confidential_to_doorkeeper_application.rb
+++ b/stash_api/db/migrate/20180822222838_add_confidential_to_doorkeeper_application.rb
@@ -1,0 +1,11 @@
+class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true # maintaining backwards compatibility: require secrets
+    )
+  end
+end


### PR DESCRIPTION
These are just updates to the Doorkeeper gem to keep up to date with security updates.  We're apparently not vulnerable because not using implicit grant.  Good to update, anyway.