### PR TITLE
Dataset identifiers

### DIFF
--- a/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash_api/app/controllers/stash_api/application_controller.rb
@@ -29,7 +29,9 @@ module StashApi
     end
 
     def require_stash_identifier(doi:)
-      @stash_identifier = StashEngine::Identifier.find_with_id(doi)
+      # check to see if the identifier is actually an id and not a DOI first
+      @stash_identifier = StashEngine::Identifier.where(id: doi).first
+      @stash_identifier = StashEngine::Identifier.find_with_id(doi) if @stash_identifier.blank?
       render json: { error: 'not-found' }.to_json, status: 404 if @stash_identifier.blank?
     end
 

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -93,7 +93,14 @@ module StashApi
     private
 
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def setup_identifier_and_resource_for_put
+      # check to see if the identifier is actually an id and not a DOI first
+      if params[:id].match?(/\d+/)
+        @stash_identifier = StashEngine::Identifier.where(id: params[:id]).first
+        @resource = @stash_identifier.resources.by_version_desc.first
+        return
+      end
       id_type, id_text = params[:id].split(':', 2)
       render json: { error: 'incorrect DOI format' }.to_json, status: 404 if !id_type.casecmp('DOI').zero? || !id_text.match(%r{^10\.\S+/\S+$})
       ids = StashEngine::Identifier.where(identifier_type: id_type.upcase).where(identifier: id_text)
@@ -106,6 +113,7 @@ module StashApi
       end
     end
     # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     def do_patch
       return unless request.method == 'PATCH' && request.headers['content-type'] == 'application/json-patch+json'

--- a/stash_api/app/models/stash_api/dataset.rb
+++ b/stash_api/app/models/stash_api/dataset.rb
@@ -84,14 +84,16 @@ module StashApi
     # a simple identifier without any versions, shouldn't be happening but it did on dev at least
     def simple_identifier
       {
-        id: @se_identifier.to_s,
+        identifier: @se_identifier.to_s,
+        id: @se_identifier.id,
         message: 'identifier is missing required elements'
       }
     end
 
     def id_and_size_hash
       {
-        id: @se_identifier.to_s,
+        identifier: @se_identifier.to_s,
+        id: @se_identifier.id,
         storage_size: @se_identifier.storage_size
       }
     end

--- a/stash_api/spec/unit/models/stash_api/dataset_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_spec.rb
@@ -52,7 +52,7 @@ module StashApi
       end
 
       it 'shows an appropriate string identifier under id' do
-        expect(@metadata[:id]).to eq('doi:138/238/2238')
+        expect(@metadata[:identifier]).to eq('doi:138/238/2238')
       end
 
       it 'shows correct title' do


### PR DESCRIPTION
Datasets should be able to be referenced both by their DOI-type identifier (`identifier`) and their internal numeric id (`id`). Both should be discoverable via a GET request.