### PR TITLE
Add embargo type

### DIFF
--- a/stash_engine/db/migrate/20181008011048_add_embargo_type_to_stash_engine_embargoes.rb
+++ b/stash_engine/db/migrate/20181008011048_add_embargo_type_to_stash_engine_embargoes.rb
@@ -1,0 +1,5 @@
+class AddEmbargoTypeToStashEngineEmbargoes < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_embargoes, :embargo_type, :string
+  end
+end


### PR DESCRIPTION
Add a field to the resources table for storing the type of an embargo. This will be needed for historical data, even if embargo types are not used in the future.