### PR TITLE
Add ability to get the current status of a Dataset

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -25,6 +25,7 @@ module StashApi
       @curation_activity = StashEngine::CurationActivity.where(identifier_id: @stash_identifier.id)
       @curation_activity = @curation_activity.where(status: params[:status]) if params.key?(:status)
       @curation_activity = @curation_activity.where(user_id: @user.id) if params.key?(:user_id)
+      @curation_activity = @curation_activity.order(updated_at: :desc)
       respond_to do |format|
         format.json { render json: @curation_activity }
       end

--- a/stash_api/app/models/stash_api/dataset.rb
+++ b/stash_api/app/models/stash_api/dataset.rb
@@ -36,8 +36,10 @@ module StashApi
       # gets descriptive metadata together
       lv = in_progress || last_submitted
       return simple_identifier if lv.nil?
-      metadata = id_and_size_hash.merge(lv.metadata)
+      id_size_hsh = id_and_size_hash
+      metadata = id_size_hsh.merge(lv.metadata)
       add_embargo_date!(metadata, lv)
+      add_curation_status(metadata, id_size_hsh[:id])
       # metadata.compact!
 
       # gives the links to nearby objects
@@ -100,6 +102,10 @@ module StashApi
 
     def add_embargo_date!(hsh, version)
       hsh[:embargoEndDate] = version.resource.embargo.end_date.strftime('%Y-%m-%d') unless version.resource.embargo.nil?
+    end
+
+    def add_curation_status(hsh, id)
+      hsh[:curationStatus] = StashEngine::CurationActivity.current_status(id)
     end
 
   end

--- a/stash_api/app/models/stash_api/dataset.rb
+++ b/stash_api/app/models/stash_api/dataset.rb
@@ -105,7 +105,7 @@ module StashApi
     end
 
     def add_curation_status(hsh, id)
-      hsh[:curationStatus] = StashEngine::CurationActivity.current_status(id)
+      hsh[:curationStatus] = StashEngine::CurationActivity.curation_status(id)
     end
 
   end

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -9,7 +9,7 @@ module StashEngine
     # GET /resources/{id}/curation_activities
     def index
       @ident = Identifier.find_with_id(Resource.find_by!(id: params[:resource_id]).identifier_str)
-      @curation_activities = CurationActivity.where(identifier_id: @ident.identifier_id) unless @ident.blank?
+      @curation_activities = CurationActivity.where(identifier_id: @ident.identifier_id).order(created_at: :desc) unless @ident.blank?
       respond_to do |format|
         format.html
         format.json { render json: @curation_activities }

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -14,6 +14,14 @@ module StashEngine
                                     message: '%{value} is not a valid status' }
     validates :status, presence: true
 
+    def self.current_status(my_stash_id)
+      curation_activities = CurationActivity.where(stash_identifier: my_stash_id).order(updated_at: :desc)
+      curation_activities.each do |activity|
+        return activity.status unless activity.status == 'Status Unchanged'
+      end
+      @current_status = 'Unsubmitted'
+    end
+
     def as_json(*)
       # {"id":11,"identifier_id":1,"status":"Submitted","user_id":1,"note":"hello hello ssdfs2232343","keywords":null}
       {
@@ -22,7 +30,9 @@ module StashEngine
         status: status,
         action_taken_by: user.name,
         note: note,
-        keywords: keywords
+        keywords: keywords,
+        created_at: created_at,
+        updated_at: updated_at
       }
     end
   end

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -14,12 +14,12 @@ module StashEngine
                                     message: '%{value} is not a valid status' }
     validates :status, presence: true
 
-    def self.current_status(my_stash_id)
+    def self.curation_status(my_stash_id)
       curation_activities = CurationActivity.where(stash_identifier: my_stash_id).order(updated_at: :desc)
       curation_activities.each do |activity|
         return activity.status unless activity.status == 'Status Unchanged'
       end
-      @current_status = 'Unsubmitted'
+      @curation_status = 'Unsubmitted'
     end
 
     def as_json(*)


### PR DESCRIPTION
A dataset’s status is equal to the status of the last status-changing curation_activity that is recorded for it. If there is no curation_activity, its status is “Unsubmitted”.