### PR TITLE
Query datasets by curationStatus, publicationISSN

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -26,6 +26,7 @@ module StashApi
       @curation_activity = StashEngine::CurationActivity.where(identifier_id: @stash_identifier.id)
       @curation_activity = @curation_activity.where(status: params[:status]) if params.key?(:status)
       @curation_activity = @curation_activity.where(user_id: @user.id) if params.key?(:user_id)
+      @curation_activity = @curation_activity.order(updated_at: :desc)
       respond_to do |format|
         format.json { render json: @curation_activity }
       end

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -167,21 +167,19 @@ module StashApi
       @resource = nr
     end
 
-    def all_datasets
-      { 'stash:datasets' =>
-          StashEngine::Identifier.all.map { |i| Dataset.new(identifier: "#{i.identifier_type}:#{i.identifier}").metadata } }
+    def datasets_with_mapped_metadata(datasets_to_map)
+      datasets_to_map.map { |i| Dataset.new(identifier: "#{i.identifier_type}:#{i.identifier}").metadata }
     end
 
-    def paged_datasets
-      all_count = StashEngine::Identifier.all.count
-      results = StashEngine::Identifier.all.limit(page_size).offset(page_size * (page - 1))
-      results = results.map { |i| Dataset.new(identifier: "#{i.identifier_type}:#{i.identifier}").metadata }
-      paging_hash_results(all_count, results)
+    def paged_datasets(datasets_to_page)
+      all_count = datasets_to_page.count
+      results = datasets_to_page.slice(page_size * (page - 1), page_size)
+      paging_hash_results(all_count, datasets_with_mapped_metadata(results))
     end
 
     def paging_hash_results(all_count, results)
       {
-        '_links' => paging_hash(result_count: all_count),
+        '_links' => paging_hash(result_count: results.count),
         count: results.count,
         total: all_count,
         '_embedded' => { 'stash:datasets' => results }

--- a/stash_api/app/models/stash_api/dataset.rb
+++ b/stash_api/app/models/stash_api/dataset.rb
@@ -36,8 +36,10 @@ module StashApi
       # gets descriptive metadata together
       lv = in_progress || last_submitted
       return simple_identifier if lv.nil?
-      metadata = id_and_size_hash.merge(lv.metadata)
+      id_size_hsh = id_and_size_hash
+      metadata = id_size_hsh.merge(lv.metadata)
       add_embargo_date!(metadata, lv)
+      add_curation_status(metadata, id_size_hsh[:id])
       # metadata.compact!
 
       # gives the links to nearby objects
@@ -100,6 +102,10 @@ module StashApi
 
     def add_embargo_date!(hsh, version)
       hsh[:embargoEndDate] = version.resource.embargo.end_date.strftime('%Y-%m-%d') unless version.resource.embargo.nil?
+    end
+
+    def add_curation_status(hsh, id)
+      hsh[:curationStatus] = StashEngine::CurationActivity.current_status(id)
     end
 
   end

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -9,7 +9,7 @@ module StashEngine
     # GET /resources/{id}/curation_activities
     def index
       @ident = Identifier.find_with_id(Resource.find_by!(id: params[:resource_id]).identifier_str)
-      @curation_activities = CurationActivity.where(identifier_id: @ident.identifier_id) unless @ident.blank?
+      @curation_activities = CurationActivity.where(identifier_id: @ident.identifier_id).order(created_at: :desc) unless @ident.blank?
       respond_to do |format|
         format.html
         format.json { render json: @curation_activities }

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -14,6 +14,14 @@ module StashEngine
                                     message: '%{value} is not a valid status' }
     validates :status, presence: true
 
+    def self.current_status(my_stash_id)
+      curation_activities = CurationActivity.where(stash_identifier: my_stash_id).order(updated_at: :desc)
+      curation_activities.each do |activity|
+        return activity.status unless activity.status == 'Status Unchanged'
+      end
+      @current_status = 'Unsubmitted'
+    end
+
     def as_json(*)
       # {"id":11,"identifier_id":1,"status":"Submitted","user_id":1,"note":"hello hello ssdfs2232343","keywords":null}
       {
@@ -22,7 +30,9 @@ module StashEngine
         status: status,
         action_taken_by: user.name,
         note: note,
-        keywords: keywords
+        keywords: keywords,
+        created_at: created_at,
+        updated_at: updated_at
       }
     end
   end

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -3,6 +3,8 @@ module StashEngine
     has_many :resources, class_name: 'StashEngine::Resource', dependent: :destroy
     has_many :orcid_invitations, class_name: 'StashEngine::OrcidInvitation', dependent: :destroy
     has_one :counter_stat, class_name: 'StashEngine::CounterStat', dependent: :destroy
+    has_many :curation_activities, :class_name => 'StashEngine::CurationActivity'
+    has_many :internal_data, :class_name => 'StashEngine::InternalDatum'
     # has_many :counter_citations, class_name: 'StashEngine::CounterCitation', dependent: :destroy
     # before_create :build_associations
 

--- a/stash_engine/app/models/stash_engine/internal_datum.rb
+++ b/stash_engine/app/models/stash_engine/internal_datum.rb
@@ -1,7 +1,7 @@
 module StashEngine
   class InternalDatum < ActiveRecord::Base
-    belongs_to :identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
-    validates :data_type, inclusion: { in: %w[manuscriptNumber mismatchedDOI duplicateItem formerManuscriptNumber publicationName],
+    belongs_to :stash_identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
+    validates :data_type, inclusion: { in: %w[manuscriptNumber mismatchedDOI duplicateItem formerManuscriptNumber publicationISSN],
                                        message: '%{value} is not a valid data type' }
     validates :data_type, presence: true
     validates :value, presence: true


### PR DESCRIPTION
This includes https://github.com/CDL-Dryad/stash/pull/34. I reworked the index method of datasets_controller to allow using query strings for curationStatus and publicationISSN, as well as the default all-results if no query string is specified. Paging should still work as before. 