### PR TITLE
Mint id early to avoid problems with non-existent stash_engine_identifier objects

### DIFF
--- a/stash_engine/app/controllers/stash_engine/resources_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/resources_controller.rb
@@ -47,6 +47,10 @@ module StashEngine
     # POST /resources.json
     def create
       resource = Resource.create(user_id: current_user.id, current_editor_id: current_user.id, tenant_id: current_user.tenant_id)
+      my_id = StashEngine.repository.mint_id(resource: resource)
+      id_type, id_text = my_id.split(':', 2)
+      db_id_obj = Identifier.create(identifier: id_text, identifier_type: id_type.upcase)
+      resource.update!(identifier_id: db_id_obj.id)
       resource.fill_blank_author!
       redirect_to metadata_entry_pages_find_or_create_path(resource_id: resource.id)
     end

--- a/stash_engine/lib/tasks/identifier_rake_functions.rb
+++ b/stash_engine/lib/tasks/identifier_rake_functions.rb
@@ -1,0 +1,29 @@
+module IdentifierRakeFunctions
+  def self.update_identifiers
+    resources = StashEngine::Resource.joins('LEFT JOIN stash_engine_identifiers ON ' \
+      'stash_engine_resources.identifier_id = stash_engine_identifiers.id')
+      .where('stash_engine_identifiers.id IS NULL OR stash_engine_identifiers.identifier IS NULL')
+
+    puts "There are #{resources.count} stash_engine_resources without stash_engine_identifiers"
+
+    resources.each do |resource|
+      next if resource&.identifier&.indentifier # double-check just in case something has changed since query
+      puts "Generating identifier for stash_engine_resource #{resource.id}: #{resource.title}"
+      make_identifier(resource: resource)
+    end
+  end
+
+  private_class_method
+
+  def self.make_identifier(resource:)
+    my_id = StashEngine.repository.mint_id(resource: resource)
+    id_type, id_text = my_id.split(':', 2)
+    if resource.identifier.nil?
+      # create record for identifier and add it to resource
+      db_id_obj = StashEngine::Identifier.create(identifier: id_text, identifier_type: id_type.upcase)
+      resource.update!(identifier_id: db_id_obj.id)
+      return
+    end
+    resource.identifier.update!(identifier_id: db_id_obj.id)
+  end
+end

--- a/stash_engine/lib/tasks/identifier_rake_functions.rb
+++ b/stash_engine/lib/tasks/identifier_rake_functions.rb
@@ -20,10 +20,10 @@ module IdentifierRakeFunctions
     id_type, id_text = my_id.split(':', 2)
     if resource.identifier.nil?
       # create record for identifier and add it to resource
-      db_id_obj = StashEngine::Identifier.create(identifier: id_text, identifier_type: id_type.upcase)
+      db_id_obj = StashEngine::Identifier.create!(identifier: id_text, identifier_type: id_type.upcase)
       resource.update!(identifier_id: db_id_obj.id)
       return
     end
-    resource.identifier.update!(identifier_id: db_id_obj.id)
+    resource.identifier.update!(identifier: id_text, identifier_type: id_type.upcase)
   end
 end

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -1,4 +1,6 @@
-# desc "Explaining what the task does"
-# task :stash_engine do
-#   # Task goes here
-# end
+require_relative 'identifier_rake_functions'
+
+desc 'Give resources missing a stash_engine_identifier one (run from main app, not engine)'
+task fix_missing_stash_engine_identifiers: :environment do # loads rails environment
+  IdentifierRakeFunctions.update_identifiers
+end


### PR DESCRIPTION
This task is based on this issue.  https://github.com/CDL-Dryad/dryad-product-roadmap/issues/109

The easiest way to test will be to log in to the UI and create a new dataset and you could then trace it in the database to see that a stash_engine_identifier has been created for the stash_engine_resource.

I have also tested out submissions made this way in the UI and it worked correctly and doesn't re-mint or change the identifier.

----

I also added a rake task you can run from the main application with `RAILS_ENV=<your-env-here> rake fix_missing_stash_engine_identifiers`

If you run it, it will find and update any missing identifiers.  It's a good thing to do so things are consistent for old resources that might not have them when we transition from old code to new.

If you want to test on our current shared dev DB, you can delete the stash_engine_identifiers indicated in the identifier_ids in stash_engine_resources 5, 36, 59 and 62.  Delete those indicated identifiers directly in the database and it will and then run the script and create new identifiers for those.