### PR TITLE
Fix for Authors not going into API

### DIFF
--- a/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash_api/app/models/stash_api/dataset_parser.rb
@@ -72,13 +72,14 @@ module StashApi
     end
 
     def add_author(json_author: author)
-      a = StashEngine::Author.create(
+      a = StashEngine::Author.new(
         author_first_name: json_author[:firstName],
         author_last_name: json_author[:lastName],
         author_email: json_author[:email],
         author_orcid: @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
         resource_id: @resource.id
       )
+      a.save(validate: false) # we can validate on submission, keeps from saving otherwise
       a.affiliation_by_name(json_author[:affiliation]) unless json_author[:affiliation].blank?
     end
 

--- a/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -92,6 +92,31 @@ module StashApi
         expect(author.author_email).to eq(@basic_metadata[:authors].first['email'])
       end
 
+      it 'allows bad (not blank, but invalid) emails' do
+        @basic_metadata = {
+          'title' => 'Visualizing Congestion Control Using Self-Learning Epistemologies',
+          'authors' => [
+            {
+              'firstName' => 'Wanda',
+              'lastName' => 'Jackson',
+              'email' => 'grog-to-drink',
+              'affiliation' => 'never'
+            }
+          ],
+          'abstract' =>
+                'Cyberneticists agree that concurrent models are an interesting new topic in the field of machine learning.',
+          'userId' => @user2.id
+        }.with_indifferent_access
+
+        dp = DatasetParser.new(hash: @basic_metadata, id: nil, user: @user)
+        @stash_identifier = dp.parse
+        resource = @stash_identifier.resources.first
+        author = resource.authors.first
+        expect(author.author_first_name).to eq(@basic_metadata[:authors].first['firstName'])
+        expect(author.author_last_name).to eq(@basic_metadata[:authors].first['lastName'])
+        expect(author.author_email).to eq(@basic_metadata[:authors].first['email'])
+      end
+
       it 'creates the abstract' do
         resource = @stash_identifier.resources.first
         des = resource.descriptions.first


### PR DESCRIPTION
The authors had invalid email addresses and were being rolled back.  I believe it was accepting nil or valid ones.

Allowing people to put in emails like "none" and bypassing validation of them.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/107