### PR TITLE
Skipping identifier reservation if skippingDataciteUpdate

### DIFF
--- a/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -76,6 +76,7 @@ module Stash
       def ensure_identifier
         if resource.identifier && resource.identifier.identifier # if identifier has value
           log_info("ensuring identifier is reserved for resource #{resource_id}, ident: #{resource.identifier}")
+          return resource.identifier.to_s if resource.skip_datacite_update
           return id_helper.reserve_id(doi: resource.identifier.to_s) # reserve_id is smart and doesn't reserve again if it already exists
         end
         log_info("minting new identifier for resource #{resource_id}")

--- a/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash_api/app/models/stash_api/dataset_parser.rb
@@ -72,13 +72,14 @@ module StashApi
     end
 
     def add_author(json_author: author)
-      a = StashEngine::Author.create(
+      a = StashEngine::Author.new(
         author_first_name: json_author[:firstName],
         author_last_name: json_author[:lastName],
         author_email: json_author[:email],
         author_orcid: @previous_orcids["#{json_author[:firstName]} #{json_author[:lastName]}"],
         resource_id: @resource.id
       )
+      a.save(validate: false) # we can validate on submission, keeps from saving otherwise
       a.affiliation_by_name(json_author[:affiliation]) unless json_author[:affiliation].blank?
     end
 

--- a/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -92,6 +92,31 @@ module StashApi
         expect(author.author_email).to eq(@basic_metadata[:authors].first['email'])
       end
 
+      it 'allows bad (not blank, but invalid) emails' do
+        @basic_metadata = {
+          'title' => 'Visualizing Congestion Control Using Self-Learning Epistemologies',
+          'authors' => [
+            {
+              'firstName' => 'Wanda',
+              'lastName' => 'Jackson',
+              'email' => 'grog-to-drink',
+              'affiliation' => 'never'
+            }
+          ],
+          'abstract' =>
+                'Cyberneticists agree that concurrent models are an interesting new topic in the field of machine learning.',
+          'userId' => @user2.id
+        }.with_indifferent_access
+
+        dp = DatasetParser.new(hash: @basic_metadata, id: nil, user: @user)
+        @stash_identifier = dp.parse
+        resource = @stash_identifier.resources.first
+        author = resource.authors.first
+        expect(author.author_first_name).to eq(@basic_metadata[:authors].first['firstName'])
+        expect(author.author_last_name).to eq(@basic_metadata[:authors].first['lastName'])
+        expect(author.author_email).to eq(@basic_metadata[:authors].first['email'])
+      end
+
       it 'creates the abstract' do
         resource = @stash_identifier.resources.first
         des = resource.descriptions.first


### PR DESCRIPTION
This was erroring because of trying to register an identifier.

I tested and skipDataciteUpdate now seems to work.

The only thing I worry about is that it was dispatching it to EZID instead of DataCite, which seemed wrong, but I tested again and traced logs while i was using my user with Dryad api access and it seemed to be dispatching it correctly to Datacite instead of EZID every time I tested.

Please test and let me know if you run into any problems, Ryan.  The skipDataciteUpdate seems to work.  I'd tested this earlier and I'm not sure why it was having this problem now.