### PR TITLE
When using loosenValidation, do not require an abstract

### DIFF
--- a/stash_datacite/app/models/stash_datacite/resource/completions.rb
+++ b/stash_datacite/app/models/stash_datacite/resource/completions.rb
@@ -140,7 +140,6 @@ module StashDatacite
       def relaxed_warnings
         messages = []
         messages << 'Add a dataset title' unless title
-        messages << 'Add an abstract' unless abstract
         messages << 'You must have at least one author name and they need to be complete' unless author_name
         messages << 'Fix or remove upload URLs that were unable to validate' unless urls_validated?
         messages


### PR DESCRIPTION
A refinement of #40, allowing items submitted through the API to go through without an abstract. There are a few items in Dryad Classic that do not have abstracts, and it seems better to allow them rather than putting in a dummy abstract.