### PR TITLE
Set/add internal data

### DIFF
--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -113,6 +113,7 @@ module StashApi
     def set_internal_datum
       if StashEngine::InternalDatum.allows_multiple(params[:data_type])
         render json: { error: params[:data_type] + ' allows multiple entries, use add_internal_datum' }.to_json, status: 404
+        return
       else
         @datum = StashEngine::InternalDatum.where(data_type: params[:data_type], identifier_id: @stash_identifier.id).first
         @datum = StashEngine::InternalDatum.create(data_type: params[:data_type], stash_identifier: @stash_identifier, value: params[:value]) if @datum.nil?
@@ -124,7 +125,10 @@ module StashApi
 
     # post /datasets/<id>/add_internal_datum
     def add_internal_datum
-      render json: { error: params[:data_type] + ' does not allow multiple entries, use set_internal_datum' }.to_json, status: 404 unless StashEngine::InternalDatum.allows_multiple(params[:data_type])
+      unless StashEngine::InternalDatum.allows_multiple(params[:data_type])
+        render json: { error: params[:data_type] + ' does not allow multiple entries, use set_internal_datum' }.to_json, status: 404
+        return
+      end
       @datum = StashEngine::InternalDatum.create(data_type: params[:data_type], stash_identifier: @stash_identifier, value: params[:value])
       render json: @datum, status: 200
     end

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -107,6 +107,8 @@ module StashApi
       end
     end
 
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/LineLength
     # post /datasets/<id>/set_internal_datum
     def set_internal_datum
       if StashEngine::InternalDatum.allows_multiple(params[:data_type])
@@ -118,6 +120,7 @@ module StashApi
         render json: @datum, status: 200
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # post /datasets/<id>/add_internal_datum
     def add_internal_datum
@@ -125,6 +128,7 @@ module StashApi
       @datum = StashEngine::InternalDatum.create(data_type: params[:data_type], stash_identifier: @stash_identifier, value: params[:value])
       render json: @datum, status: 200
     end
+    # rubocop:enable Metrics/LineLength
 
     def get_stash_identifier(id)
       # check to see if the identifier is actually an id and not a DOI first

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -12,7 +12,7 @@ module StashApi
 
     before_action :require_json_headers, only: %i[show create index update]
     before_action -> { require_stash_identifier(doi: params[:id]) }, only: %i[show download]
-    before_action :setup_identifier_and_resource_for_put, only: %i[update]
+    before_action :setup_identifier_and_resource_for_put, only: %i[update set_internal_datum add_internal_datum]
     before_action :doorkeeper_authorize!, only: %i[create update]
     before_action :require_api_user, only: %i[create update]
     # before_action :require_in_progress_resource, only: :update
@@ -105,6 +105,25 @@ module StashApi
       else
         render text: 'download for this dataset is unavailable', status: 404
       end
+    end
+
+    # post /datasets/<id>/set_internal_datum
+    def set_internal_datum
+      if StashEngine::InternalDatum.allows_multiple(params[:data_type])
+        render json: { error: params[:data_type] + ' allows multiple entries, use add_internal_datum' }.to_json, status: 404
+      else
+        @datum = StashEngine::InternalDatum.where(data_type: params[:data_type], identifier_id: @stash_identifier.id).first
+        @datum = StashEngine::InternalDatum.create(data_type: params[:data_type], stash_identifier: @stash_identifier, value: params[:value]) if @datum.nil?
+        @datum.update!(value: params[:value])
+        render json: @datum, status: 200
+      end
+    end
+
+    # post /datasets/<id>/add_internal_datum
+    def add_internal_datum
+      render json: { error: params[:data_type] + ' does not allow multiple entries, use set_internal_datum' }.to_json, status: 404 unless StashEngine::InternalDatum.allows_multiple(params[:data_type])
+      @datum = StashEngine::InternalDatum.create(data_type: params[:data_type], stash_identifier: @stash_identifier, value: params[:value])
+      render json: @datum, status: 200
     end
 
     def get_stash_identifier(id)

--- a/stash_api/config/routes.rb
+++ b/stash_api/config/routes.rb
@@ -7,7 +7,15 @@ StashApi::Engine.routes.draw do
   match '/test', to: 'general#test', via: [:get, :post]
 
   resources :datasets, shallow: true, id: /[^\s\/]+?/, format: /json|xml|yaml/ do
-    get 'download', on: :member
+    member do
+      get 'download'
+    end
+    member do
+      post 'set_internal_datum'
+    end
+    member do
+      post 'add_internal_datum'
+    end
     resources :internal_data, shallow: true
     resources :curation_activity, shallow: false
     resources :versions, shallow: true do

--- a/stash_engine/app/models/stash_engine/internal_datum.rb
+++ b/stash_engine/app/models/stash_engine/internal_datum.rb
@@ -9,5 +9,16 @@ module StashEngine
     def self.data_type(type)
       where('data_type = ?', type)
     end
+
+    def self.allows_multiple(type)
+      case type
+      when 'manuscriptNumber', 'publicationISSN'
+        false
+      when 'mismatchedDOI', 'duplicateItem', 'formerManuscriptNumber'
+        true
+      else
+        false
+      end
+    end
   end
 end


### PR DESCRIPTION
We need to be able to quickly either update particular sorts of internal data or add a new entry to them.

You should be able to do a POST request to either `api/datasets/<id>/add_internal_datum` or `api/datasets/<id>/set_internal_datum`, depending on the type of data. The body should be JSON in the form of `{"data_type":"mismatchedDOI","value":"223342”}`

There can only be one value for “publicationISSN” or “manuscriptNumber,” but “mismatchedDOI,” “formerManuscriptNumber,” and “duplicateItem” can have multiple values.