### PR TITLE
Paging, sorting and filtering on the Admin page

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -71,7 +71,7 @@ module StashEngine
         'ON `stash_engine_identifiers`.`id` = `stash_engine_identifier_states`.`identifier_id` ' \
         'INNER JOIN `stash_engine_curation_activities` ' \
         'ON `stash_engine_identifier_states`.`curation_activity_id` = `stash_engine_curation_activities`.`id` ' \
-        'INNER JOIN `stash_engine_users` user2 ' \
+        'LEFT JOIN `stash_engine_users` user2 ' \
         'ON `stash_engine_curation_activities`.`user_id` = user2.`id`')
     end
 

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -7,7 +7,7 @@ module StashEngine
     before_action :setup_paging
     before_action :setup_ds_sorting
 
-    TENANT_IDS = Tenant.all.map{|i| i.tenant_id }
+    TENANT_IDS = Tenant.all.map(&:tenant_id)
     CURATION_STATUSES = CurationActivity.validators_on(:status).first.options[:in]
 
     # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
@@ -77,14 +77,13 @@ module StashEngine
 
     def add_filters(query_obj:)
       if TENANT_IDS.include?(params[:tenant]) && current_user.role == 'superuser'
-        query_obj = query_obj.where("stash_engine_resources.tenant_id = ?", params[:tenant])
+        query_obj = query_obj.where('stash_engine_resources.tenant_id = ?', params[:tenant])
       end
       if CURATION_STATUSES.include?(params[:curation_status])
-        query_obj = query_obj.where("stash_engine_identifier_states.current_curation_status = ?", params[:curation_status])
+        query_obj = query_obj.where('stash_engine_identifier_states.current_curation_status = ?', params[:curation_status])
       end
       query_obj
     end
-
 
   end
 end

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -5,6 +5,7 @@ module StashEngine
     include SharedSecurityController
     before_action :require_admin
     before_action :setup_paging
+    before_action :setup_ds_sorting
 
     # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
     def index
@@ -20,6 +21,18 @@ module StashEngine
     def setup_paging
       @page = params[:page] || '1'
       @page_size = (params[:page_size].blank? || params[:page_size] != '1000000' ? '10' : '1000000')
+    end
+
+    def setup_ds_sorting
+      title_sort = SortableTable::SortColumnCustomDefinition.new('name',
+                                                                asc: 'stash_engine_resources.title asc',
+                                                                desc: 'stash_engine_resources.title desc')
+      # role_sort = SortableTable::SortColumnDefinition.new('role')
+      # login_time_sort = SortableTable::SortColumnDefinition.new('last_login')
+      # sort_table = SortableTable::SortTable.new([name_sort, institution_sort, role_sort, login_time_sort])
+      # sort_table.sort_column(params[:sort], params[:direction])
+      sort_table = SortableTable::SortTable.new([title_sort])
+      @sort_column = sort_table.sort_column(params[:sort], params[:direction])
     end
 
     def build_table_query

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -23,26 +23,51 @@ module StashEngine
       @page_size = (params[:page_size].blank? || params[:page_size] != '1000000' ? '10' : '1000000')
     end
 
+    # rubocop:disable Metrics/MethodLength
     def setup_ds_sorting
-      title_sort = SortableTable::SortColumnCustomDefinition.new('name',
-                                                                asc: 'stash_engine_resources.title asc',
-                                                                desc: 'stash_engine_resources.title desc')
-      # role_sort = SortableTable::SortColumnDefinition.new('role')
-      # login_time_sort = SortableTable::SortColumnDefinition.new('last_login')
-      # sort_table = SortableTable::SortTable.new([name_sort, institution_sort, role_sort, login_time_sort])
-      # sort_table.sort_column(params[:sort], params[:direction])
-      sort_table = SortableTable::SortTable.new([title_sort])
+      title_sort = SortableTable::SortColumnCustomDefinition.new('title', asc: 'stash_engine_resources.title asc',
+                                                                          desc: 'stash_engine_resources.title desc')
+      status_sort = SortableTable::SortColumnCustomDefinition.new('status',
+                                                                  asc: 'stash_engine_identifier_states.current_curation_status asc',
+                                                                  desc: 'stash_engine_identifier_states.current_curation_status desc')
+      author_sort = SortableTable::SortColumnCustomDefinition.new('author', asc: 'user1.last_name asc, user1.first_name asc',
+                                                                            desc: 'user1.last_name desc, user1.first_name desc')
+      doi_sort = SortableTable::SortColumnCustomDefinition.new('doi', asc: 'stash_engine_identifiers.identifier asc',
+                                                                      desc: 'stash_engine_identifiers.identifier desc')
+      last_modified_sort = SortableTable::SortColumnCustomDefinition.new('last_modified',
+                                                                         asc: 'stash_engine_curation_activities.updated_at asc',
+                                                                         desc: 'stash_engine_curation_activities.updated_at desc')
+      modified_by_sort = SortableTable::SortColumnCustomDefinition.new('modified_by',
+                                                                       asc: 'user2.last_name asc, user2.first_name asc',
+                                                                       desc: 'user2.last_name desc, user2.first_name desc')
+      size_sort = SortableTable::SortColumnCustomDefinition.new('size', asc: 'storage_size asc', desc: 'storage_size desc')
+
+      sort_table = SortableTable::SortTable.new([title_sort, status_sort, author_sort, doi_sort, last_modified_sort, modified_by_sort, size_sort])
       @sort_column = sort_table.sort_column(params[:sort], params[:direction])
     end
+    # rubocop:enable Metrics/MethodLength
 
     def build_table_query
       ds_identifiers = base_table_join
       ds_identifiers = ds_identifiers.where('stash_engine_resources.tenant_id = ?', current_user.tenant_id) if current_user.role != 'superuser'
-      ds_identifiers.page(@page).per(@page_size)
+      ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)
     end
 
     def base_table_join
-      Identifier.joins([{ latest_resource: :user }, { identifier_state: { curation_activity: :user } }])
+      # the following works, but then sorting becomes ambiguous because user joined twice
+      # also the joins aren't quite right because of the way itentifier state is set up and the associations
+      # Identifier.joins([{ latest_resource: :user }, { identifier_state: { curation_activity: :user } }])
+      # using these table abbreviations: user1, user2
+      Identifier.joins('INNER JOIN `stash_engine_resources` ' \
+        'ON `stash_engine_identifiers`.`latest_resource_id` = `stash_engine_resources`.`id` ' \
+        'INNER JOIN `stash_engine_users` user1 ' \
+        'ON `stash_engine_resources`.`user_id` = user1.`id` ' \
+        'INNER JOIN `stash_engine_identifier_states` ' \
+        'ON `stash_engine_identifiers`.`id` = `stash_engine_identifier_states`.`identifier_id` ' \
+        'INNER JOIN `stash_engine_curation_activities` ' \
+        'ON `stash_engine_identifier_states`.`curation_activity_id` = `stash_engine_curation_activities`.`id` ' \
+        'INNER JOIN `stash_engine_users` user2 ' \
+        'ON `stash_engine_curation_activities`.`user_id` = user2.`id`')
     end
   end
 end

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -4,26 +4,26 @@
     <th class="c-admin-table <%= sort_display('title', @sort_column) %>" colspan="2">
       <%= sort_by 'title', title: 'Title', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table" colspan="2">
-      Status
+    <th class="c-admin-table <%= sort_display('status', @sort_column) %>" colspan="2">
+      <%= sort_by 'status', title: 'Status', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table">
-      Author
+    <th class="c-admin-table <%= sort_display('author', @sort_column) %>">
+      <%= sort_by 'author', title: 'Author', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table">
-      DOI
+    <th class="c-admin-table <%= sort_display('doi', @sort_column) %>">
+      <%= sort_by 'doi', title: 'DOI', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table" colspan="2">
-      Last modified
+    <th class="c-admin-table <%= sort_display('last_modified', @sort_column) %>" colspan="2">
+      <%= sort_by 'last_modified', title: 'Last Modified', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table">
-      Last modified by
+    <th class="c-admin-table <%= sort_display('modified_by', @sort_column) %>">
+      <%= sort_by 'modified_by', title: 'Last modified by', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table">
-      Size
+    <th class="c-admin-table <%= sort_display('size', @sort_column) %>">
+      <%= sort_by 'size', title: 'Size', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table" colspan="2">
-      Publication date
+    <th class="c-admin-table <%= sort_display('publication_date', @sort_column) %>" colspan="2">
+      <%= sort_by 'publication_date', title: 'Publication Date', current_column: @sort_column %>
     </th>
   </tr>
 

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -1,8 +1,8 @@
 <%# locals: ds_identifiers %>
 <table class="c-lined-table">
   <tr class="c-lined-table__head">
-    <th class="c-admin-table" colspan="2">
-      Title
+    <th class="c-admin-table <%= sort_display('title', @sort_column) %>" colspan="2">
+      <%= sort_by 'title', title: 'Title', current_column: @sort_column %>
     </th>
     <th class="c-admin-table" colspan="2">
       Status

--- a/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -1,14 +1,24 @@
 <% # takes locals of institution_list, status_list %>
-  <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get' ) do -%>
+  <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'filter_form' ) do -%>
     <div class="c-horizontal-form__input--filter-by">Filter by:</div>
     <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
                    class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>
     <%= select_tag(:curation_status, options_for_select( [['Status', '']] + status_select, params[:curation_status]),
                    class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
-    <a href="#" class="c-horizontal-form__input">Reset all filters</a>
+    <a href="#" class="c-horizontal-form__input" id="filter_resetter">Reset all filters</a>
 
-    <% params.except(:controller, :action, :tenant, :curation_status, :commit).each_pair do |k,v| %>
+    <% params.except(:controller, :action, :tenant, :curation_status, :commit, :page, :page_size, :show_all).each_pair do |k,v| %>
       <%= hidden_field_tag k, v %>
     <% end %>
   <% end -%>
 </div>
+
+<script>
+  // put this in here because it goes along with this form only
+  $("#filter_resetter").click(function(e) {
+    e.preventDefault();
+    $("#tenant option[value='']").prop('selected',true);
+    $("#curation_status option[value='']").prop('selected',true);
+    $("#filter_form").submit();
+  });
+</script>


### PR DESCRIPTION
You can test by logging in as a superuser and then clicking the admin link.

We don't have a lot of data (it was easier to test before with more variety).

Should be able to sort, filter and page through things.

There is no user information for the unsubmitted status, it seems like.

We were waiting on publication date for a conversation about what it meant, exactly, with publishing and versioning and if it would really always be the last status.

This depends on the previous admin features.