### PR TITLE
Setting curation status for a dataset

### DIFF
--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -113,7 +113,7 @@ module StashApi
     def set_internal_datum
       if StashEngine::InternalDatum.allows_multiple(params[:data_type])
         render json: { error: params[:data_type] + ' allows multiple entries, use add_internal_datum' }.to_json, status: 404
-        return
+        nil
       else
         @datum = StashEngine::InternalDatum.where(data_type: params[:data_type], identifier_id: @stash_identifier.id).first
         @datum = StashEngine::InternalDatum.create(data_type: params[:data_type], stash_identifier: @stash_identifier, value: params[:value]) if @datum.nil?

--- a/stash_datacite/app/models/stash_datacite/description.rb
+++ b/stash_datacite/app/models/stash_datacite/description.rb
@@ -53,5 +53,11 @@ module StashDatacite
       return nil if description_type_friendly.nil?
       Description.description_type_mapping_obj(description_type_friendly)
     end
+
+    def update_search_words
+      resource&.identifier&.update_search_words! if description_type == 'abstract' && description_changed?
+    end
+
+    after_save :update_search_words
   end
 end

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -92,7 +92,7 @@ module StashEngine
 
     def plussed_query
       return nil if params[:q].blank?
-      params[:q].split.map { |item| "+#{item}" unless %w[+ - *].include?(item[0]) }.compact.join(' ')
+      params[:q].split.map { |item| "+#{item}*" unless %w[+ - *].include?(item[0]) }.compact.join(' ')
     end
 
   end

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -53,12 +53,10 @@ module StashEngine
     def build_table_query
       ds_identifiers = base_table_join
       ds_identifiers = ds_identifiers.where('stash_engine_resources.tenant_id = ?', current_user.tenant_id) if current_user.role != 'superuser'
-      # This search interface is insane and we can't sort by relevance because of the other dumb sorts, so limiting score so we don't
-      # get basically an OR of any document that contains any one of the words and it would make it harder for people to narrow
-      # down to anything useful without the limit on relevance score.
-      #
+
       # We'll have to play with this search to get it to be reasonable with the insane interface so that it narrows to a small enough
       # set so that it is useful to people for finding something and a large enough set to have what they want without hunting too long.
+      # It doesn't really support sorting by relevance because of the other sorts.
       ds_identifiers = ds_identifiers.where('MATCH(search_words) AGAINST(?) > 0.5', params[:q]) unless params[:q].blank?
       ds_identifiers = add_filters(query_obj: ds_identifiers)
       ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -53,11 +53,7 @@ module StashEngine
     def build_table_query
       ds_identifiers = base_table_join
       ds_identifiers = ds_identifiers.where('stash_engine_resources.tenant_id = ?', current_user.tenant_id) if current_user.role != 'superuser'
-      # doing plusses and boolean mode to require all words, otherwise it does an OR query which returns many results with
-      # common words.  I think we want this to be more like filtering than ranked searching from a long list because of
-      # all the other crap on the page in this one table.
-      pq = plussed_query
-      ds_identifiers = ds_identifiers.where('MATCH(search_words) AGAINST(? IN BOOLEAN MODE)', pq) unless pq.blank?
+      ds_identifiers = ds_identifiers.where('MATCH(search_words) AGAINST(?) > 0.2', params[:q]) unless params[:q].blank?
       ds_identifiers = add_filters(query_obj: ds_identifiers)
       ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)
     end
@@ -88,11 +84,6 @@ module StashEngine
         query_obj = query_obj.where('stash_engine_identifier_states.current_curation_status = ?', params[:curation_status])
       end
       query_obj
-    end
-
-    def plussed_query
-      return nil if params[:q].blank?
-      params[:q].split.map { |item| "+#{item}*" unless %w[+ - *].include?(item[0]) }.compact.join(' ')
     end
 
   end

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -4,8 +4,8 @@ module StashEngine
   class AdminDatasetsController < ApplicationController
     include SharedSecurityController
     before_action :require_admin
-    before_action :setup_paging
-    before_action :setup_ds_sorting
+    before_action :setup_paging, only: [:index]
+    before_action :setup_ds_sorting, only: [:index]
 
     TENANT_IDS = Tenant.all.map(&:tenant_id)
     CURATION_STATUSES = CurationActivity.validators_on(:status).first.options[:in]
@@ -17,6 +17,16 @@ module StashEngine
       @seven_day_stats = Stats.new(tenant_id: my_tenant_id, since: (Time.new - 7.days))
 
       @ds_identifiers = build_table_query
+    end
+
+    # Unobtrusive Javascript (UJS) to do AJAX by running javascript
+    def status_popup
+      respond_to do |format|
+        @identifier = Identifier.find(params[:id])
+        format.js do
+          byebug
+        end
+      end
     end
 
     private

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -23,9 +23,7 @@ module StashEngine
     def status_popup
       respond_to do |format|
         @identifier = Identifier.find(params[:id])
-        format.js do
-          byebug
-        end
+        format.js
       end
     end
 

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -4,7 +4,8 @@ module StashEngine
   class CurationActivityController < ApplicationController
     include SharedSecurityController
 
-    before_action :require_curator
+    before_action :require_curator, only: :index
+    before_action :ajax_require_curator, only: :status_change
 
     # GET /resources/{id}/curation_activities
     def index
@@ -16,10 +17,16 @@ module StashEngine
       end
     end
 
-    # POST /curation_activity
-    def create
-
+    # A special action for changing curation status from ajax and admin/curator area, creates new status
+    # in list for identifier, which is the ID that is passed in.  It does ajax mumbo-jumbo for admin area.
+    # this isn't RESTful
+    def status_change
+      respond_to do |format|
+        format.js do
+          @activity = CurationActivity.create(identifier_id: params[:id], status: params[:status] , user_id: current_user.id,
+                                              note: params[:note])
+        end
+      end
     end
-
   end
 end

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -23,7 +23,7 @@ module StashEngine
     def status_change
       respond_to do |format|
         format.js do
-          @activity = CurationActivity.create(identifier_id: params[:id], status: params[:status] , user_id: current_user.id,
+          @activity = CurationActivity.create(identifier_id: params[:id], status: params[:status], user_id: current_user.id,
                                               note: params[:note])
         end
       end

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -15,5 +15,11 @@ module StashEngine
         format.json { render json: @curation_activities }
       end
     end
+
+    # POST /curation_activity
+    def create
+
+    end
+
   end
 end

--- a/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -20,6 +20,10 @@ module StashEngine
       redirect_to stash_engine.dashboard_path
     end
 
+    def ajax_require_curator
+      return false unless current_user && %w[superuser].include?(current_user.role)
+    end
+
     def require_admin
       return if current_user && %w[admin superuser].include?(current_user.role)
       flash[:alert] = 'You must be an administrator to view this information.'

--- a/stash_engine/app/models/stash_engine/author.rb
+++ b/stash_engine/app/models/stash_engine/author.rb
@@ -53,6 +53,14 @@ module StashEngine
     end
     after_save :init_user_orcid
 
+    def update_search_words(force: false)
+      # intersection of two arrays to see if anything changed in the list that we care about
+      intersect = changed & %w[author_first_name author_last_name author_email author_orcid]
+      resource&.identifier&.update_search_words! if intersect.length.positive? || force == true
+    end
+    after_save :update_search_words
+    after_destroy -> { update_search_words(force: true) }
+
     private
 
     def strip_whitespace

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -145,6 +145,7 @@ module StashEngine
         end.join(' ')
         my_string << abstracts
       end
+      self.search_words = my_string
       # this updates without futher callbacks on me
       update_column :search_words, my_string
     end

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -16,6 +16,7 @@ module StashEngine
     after_update :create_or_get_identifier_state
     # has_many :counter_citations, class_name: 'StashEngine::CounterCitation', dependent: :destroy
     # before_create :build_associations
+    after_save :update_search_words!, unless: :search_words
 
     # used to build counter stat if needed, trickery to be sure one always exists to begin with
     # https://stackoverflow.com/questions/3808782/rails-best-practice-how-to-create-dependent-has-one-relations
@@ -106,7 +107,7 @@ module StashEngine
 
     def to_s
       # TODO: Make sure this is correct for all identifier types
-      "#{identifier_type.downcase}:#{identifier}"
+      "#{identifier_type&.downcase}:#{identifier}"
     end
 
     # the landing URL seems like a view component, but really it's given to people as data outside the view by way of

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -68,9 +68,14 @@ module StashEngine
       Identifier.destroy(identifier_id)
     end
 
+    def update_search_words
+      identifier&.update_search_words! if title_changed? # this method is some activerecord magic
+    end
+
     after_create :init_state_and_version, :update_stash_identifier_last_resource
     after_update :update_stash_identifier_last_resource
     after_destroy :remove_identifier_with_no_resources
+    after_save :update_search_words
 
     # shouldn't be necessary but we have some stale data floating around
     def ensure_state_and_version

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -56,7 +56,9 @@ module StashEngine
 
     def update_stash_identifier_last_resource
       return if identifier.nil?
-      identifier.update(latest_resource_id: id) # set to my resource_id
+      # identifier.update(latest_resource_id: id) # set to my resource_id
+      res = Resource.where(identifier_id: identifier_id).order(id: :desc).first
+      identifier.update_column(:latest_resource_id, res&.id) # no callbacks, does bad stuff when duplicating with amoeba dup
     end
 
     def remove_identifier_with_no_resources
@@ -73,8 +75,9 @@ module StashEngine
     end
 
     after_create :init_state_and_version, :update_stash_identifier_last_resource
+    # for some reason, after_create not working, so had to add after_update
     after_update :update_stash_identifier_last_resource
-    after_destroy :remove_identifier_with_no_resources
+    after_destroy :remove_identifier_with_no_resources, :update_stash_identifier_last_resource
     after_save :update_search_words
 
     # shouldn't be necessary but we have some stale data floating around

--- a/stash_engine/app/views/stash_engine/admin_datasets/_curation_state_popup.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_curation_state_popup.html.erb
@@ -1,0 +1,14 @@
+<% # local: identifier %>
+<div class="o-admin-dialog">
+  <p>Change Status</p>
+
+  <%= form_tag(resource_curation_activity_index_path(identifier.id), method: :post, remote: true) do -%>
+    <%= select_tag(:curation_status, options_for_select( status_select, identifier&.identifier_state&.current_curation_status),
+                   class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
+
+    <br/>
+    <%= submit_tag 'Submit' %>
+    <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog' %>
+
+  <% end %>
+</div>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_curation_state_popup.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_curation_state_popup.html.erb
@@ -1,7 +1,7 @@
 <% # local: identifier %>
 <div class="o-admin-dialog">
 
-  <%= form_tag(resource_curation_activity_index_path(identifier.id), method: :post, remote: true) do -%>
+  <%= form_tag(curation_status_change_path(identifier.id), method: :post, remote: true) do -%>
     <div class="c-input">
       <%= select_tag(:status, options_for_select( status_select, identifier&.identifier_state&.current_curation_status) ) %>
     </div>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_curation_state_popup.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_curation_state_popup.html.erb
@@ -1,12 +1,14 @@
 <% # local: identifier %>
 <div class="o-admin-dialog">
-  <p>Change Status</p>
 
   <%= form_tag(resource_curation_activity_index_path(identifier.id), method: :post, remote: true) do -%>
-    <%= select_tag(:curation_status, options_for_select( status_select, identifier&.identifier_state&.current_curation_status),
-                   class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
-
-    <br/>
+    <div class="c-input">
+      <%= select_tag(:status, options_for_select( status_select, identifier&.identifier_state&.current_curation_status) ) %>
+    </div>
+    <div class="c-input">
+      <label class="c-input__label">Notes</label>
+      <%= text_area_tag(:note, nil, class: 'c-input__textarea') %>
+    </div>
     <%= submit_tag 'Submit' %>
     <%= button_tag 'Cancel', type: 'button', id: 'cancel_dialog' %>
 

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -30,7 +30,7 @@
   <% ds_identifiers.each do |i| %>
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
-        <%= i&.latest_resource&.title %>
+        <%= link_to i&.latest_resource&.title, landing_show_path(id: i.to_s), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left">
         <button class="c-admin-edit-icon" aria-label="Edit user role" alt="Edit user role">

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -31,7 +31,7 @@
     <% latest_resource = i&.latest_resource %>
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
-        <%= link_to latest_resource&.title, landing_show_path(id: i.to_s), target: :blank %>
+        <%= link_to latest_resource&.title, show_path(id: i.to_s), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left">
         <% if latest_resource&.submitted? || latest_resource&.dataset_in_progress_editor&.id == current_user.id %>
@@ -45,9 +45,11 @@
         <%= i&.identifier_state&.current_curation_status %>
       </td>
       <td class="c-admin-hide-border-left">
-        <button class="c-admin-edit-icon" aria-label="Edit user role" alt="Edit user role">
-          <i class="fa fa-pencil" aria-hidden="true"></i>
-        </button>
+        <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'status_popup', id: i.id }, method: :get, remote: true) do -%>
+          <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
+            <i class="fa fa-pencil" aria-hidden="true"></i>
+          </button>
+        <% end %>
       </td>
       <td><%= i&.latest_resource&.user&.name %></td>
       <td><%= i.identifier %></td>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -41,14 +41,16 @@
           <% end %>
         <% end %>
       </td>
-      <td class="c-admin-hide-border-right">
+      <td class="c-admin-hide-border-right" id="js-curation-state-<%= i&.id %>">
         <%= i&.identifier_state&.current_curation_status %>
       </td>
       <td class="c-admin-hide-border-left">
-        <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'status_popup', id: i.id }, method: :get, remote: true) do -%>
-          <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
-            <i class="fa fa-pencil" aria-hidden="true"></i>
-          </button>
+        <% if current_user.role == 'superuser' %>
+          <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'status_popup', id: i.id }, method: :get, remote: true) do -%>
+            <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
+              <i class="fa fa-pencil" aria-hidden="true"></i>
+            </button>
+          <% end %>
         <% end %>
       </td>
       <td><%= i&.latest_resource&.user&.name %></td>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -28,14 +28,18 @@
   </tr>
 
   <% ds_identifiers.each do |i| %>
+    <% latest_resource = i&.latest_resource %>
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
-        <%= link_to i&.latest_resource&.title, landing_show_path(id: i.to_s), target: :blank %>
+        <%= link_to latest_resource&.title, landing_show_path(id: i.to_s), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left">
-        <button class="c-admin-edit-icon" aria-label="Edit user role" alt="Edit user role">
-          <i class="fa fa-pencil" aria-hidden="true"></i>
-        </button>
+        <% if latest_resource&.submitted? || latest_resource&.dataset_in_progress_editor&.id == current_user.id %>
+          <%= form_tag(metadata_entry_pages_new_version_path, method: :post) do -%>
+            <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
+            <%= hidden_field_tag :resource_id, latest_resource.id %>
+          <% end %>
+        <% end %>
       </td>
       <td class="c-admin-hide-border-right">
         <%= i&.identifier_state&.current_curation_status %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -1,17 +1,15 @@
-<% # takes locals of institution_list, status_list %>
-  <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'filter_form' ) do -%>
-    <div class="c-horizontal-form__input--filter-by">Filter by:</div>
-    <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
-                   class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>
-    <%= select_tag(:curation_status, options_for_select( [['Status', '']] + status_select, params[:curation_status]),
-                   class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
-    <a href="#" class="c-horizontal-form__input" id="filter_resetter">Reset all filters</a>
+<%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'filter_form' ) do -%>
+  <div class="c-horizontal-form__input--filter-by">Filter by:</div>
+  <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
+                 class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>
+  <%= select_tag(:curation_status, options_for_select( [['Status', '']] + status_select, params[:curation_status]),
+                 class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
+  <a href="#" class="c-horizontal-form__input" id="filter_resetter">Reset all filters</a>
 
-    <% params.except(:controller, :action, :tenant, :curation_status, :commit, :page, :page_size, :show_all).each_pair do |k,v| %>
-      <%= hidden_field_tag k, v %>
-    <% end %>
-  <% end -%>
-</div>
+  <% params.except(:controller, :action, :tenant, :curation_status, :commit, :page, :page_size, :show_all).each_pair do |k,v| %>
+    <%= hidden_field_tag k, v %>
+  <% end %>
+<% end -%>
 
 <script>
   // put this in here because it goes along with this form only

--- a/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
@@ -4,7 +4,7 @@
     <%= submit_tag('Search', class: 'c-horizontal-form__input' ) %>
     <a href="#" id="clear_search" class="c-horizontal-form__input">Clear Search</a>
 
-    <% params.except(:controller, :action, :q, :commit).each_pair do |k,v| %>
+    <% params.except(:controller, :action, :q, :commit, :page, :page_size, :show_all).each_pair do |k,v| %>
         <%= hidden_field_tag k, v %>
     <% end %>
   <% end %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_search.html.erb
@@ -1,11 +1,20 @@
 <div class="c-horizontal-form">
-  <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get' ) do %>
+  <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'search_form' ) do %>
     <%= search_field_tag(:q, params[:q], class: 'c-horizontal-form__input--search', placeholder: 'enter search terms' ) %>
     <%= submit_tag('Search', class: 'c-horizontal-form__input' ) %>
-    <a href="#" class="c-horizontal-form__input">Clear Search</a>
+    <a href="#" id="clear_search" class="c-horizontal-form__input">Clear Search</a>
 
     <% params.except(:controller, :action, :q, :commit).each_pair do |k,v| %>
         <%= hidden_field_tag k, v %>
     <% end %>
   <% end %>
 </div>
+
+<script>
+  // put this in here because it goes along with this form only
+  $("#clear_search").click(function(e) {
+    e.preventDefault();
+    $('#q').val("");
+    $("#search_form").submit();
+  });
+</script>

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -6,11 +6,14 @@
 <div>
   <h2>Datasets</h2>
   <%= render partial: 'search' %>
-  <%= render partial: 'filter', locals: { institution_list: @institution_list, status_list: @status_list } %>
+  <%= render partial: 'filter' %>
 
   <%= render partial: 'datasets_table', locals: { ds_identifiers: @ds_identifiers } %>
 
   <div class="c-space-paginator">
     <%= paginate @ds_identifiers, params: { page_size: @page_size, show_all: false } %>
   </div>
+</div>
+
+<div id="popup_dialog" style="display:none;">
 </div>

--- a/stash_engine/app/views/stash_engine/admin_datasets/status_popup.js.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/status_popup.js.erb
@@ -1,10 +1,9 @@
 // replace dialog div with contents of dialog text from partial
-console.log('Does this work?');
-alert('hi');
-
 
 $('#popup_dialog').html("<%= escape_javascript(
           render partial: 'stash_engine/admin_datasets/curation_state_popup', locals: { identifier: @identifier }) %>");
+
+$('.selectorUsedToCreateTheDialog').dialog('option', 'title', 'My New title');
 
 
 // now open a jquery ui modal dialog
@@ -13,8 +12,9 @@ $(function() {
     $("#popup_dialog").dialog({
         autoOpen: true,
         height: 'auto',
-        width: 'auto',
+        width: '500px',
         modal: true,
+        title: 'Change Status'
     });
 
     // make the cancel button in the dialog hide the dialog

--- a/stash_engine/app/views/stash_engine/admin_datasets/status_popup.js.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/status_popup.js.erb
@@ -1,0 +1,25 @@
+// replace dialog div with contents of dialog text from partial
+console.log('Does this work?');
+alert('hi');
+
+
+$('#popup_dialog').html("<%= escape_javascript(
+          render partial: 'stash_engine/admin_datasets/curation_state_popup', locals: { identifier: @identifier }) %>");
+
+
+// now open a jquery ui modal dialog
+$(function() {
+
+    $("#popup_dialog").dialog({
+        autoOpen: true,
+        height: 'auto',
+        width: 'auto',
+        modal: true,
+    });
+
+    // make the cancel button in the dialog hide the dialog
+    $("#cancel_dialog").click(function (e) {
+        e.preventDefault();
+        $('#popup_dialog').dialog('close');
+    });
+});

--- a/stash_engine/app/views/stash_engine/curation_activity/status_change.js.erb
+++ b/stash_engine/app/views/stash_engine/curation_activity/status_change.js.erb
@@ -1,0 +1,4 @@
+<% unless params[:status] == 'Status Unchanged' %>
+  $("#js-curation-state-<%= params[:id] %>").html("<%= @activity.status %>");
+<% end %>
+$("#popup_dialog").dialog("close");

--- a/stash_engine/config/routes.rb
+++ b/stash_engine/config/routes.rb
@@ -11,8 +11,11 @@ StashEngine::Engine.routes.draw do
       get 'show_files'
     end
     resources :internal_data
+    # TODO: curation_activity is a bit weird because it nests inside the resource in the routes but it is really related to
+    # stash_engine_identifiers, not stash_engine_resources
     resources :curation_activity
   end
+  post 'curation_status_change/:id', to: 'curation_activity#status_change', as: 'curation_status_change'
   resources :tenants, only: [:index, :show]
   resources :file_uploads do
     member do

--- a/stash_engine/db/migrate/20181116000227_add_search_words_to_identifier.rb
+++ b/stash_engine/db/migrate/20181116000227_add_search_words_to_identifier.rb
@@ -1,0 +1,6 @@
+class AddSearchWordsToIdentifier < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_identifiers, :search_words, :text
+    add_index :stash_engine_identifiers, :search_words, name: 'admin_search_index', type: :fulltext
+  end
+end

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -19,11 +19,11 @@ namespace :identifiers do
     end
   end
 
-  desc "Add searchable field contents for any identifiers missing it"
+  desc 'Add searchable field contents for any identifiers missing it'
   task add_search: :environment do
     StashEngine::Identifier.where(search_words: nil).each do |se_identifier|
-      puts "Updating identifier #{se_identifier.to_s} for search"
-      se_identifier.update_search_words
+      puts "Updating identifier #{se_identifier} for search"
+      se_identifier.update_search_words!
     end
   end
 end

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -1,19 +1,29 @@
 require_relative 'identifier_rake_functions'
 
-desc 'Give resources missing a stash_engine_identifier one (run from main app, not engine)'
-task fix_missing_stash_engine_identifiers: :environment do # loads rails environment
-  IdentifierRakeFunctions.update_identifiers
-end
+namespace :identifiers do
+  desc 'Give resources missing a stash_engine_identifier one (run from main app, not engine)'
+  task fix_missing: :environment do # loads rails environment
+    IdentifierRakeFunctions.update_identifiers
+  end
 
-desc "Update identifiers latest resource if they don't have one"
-task add_latest_resource: :environment do
-  StashEngine::Identifier.where(latest_resource_id: nil).each do |se_identifier|
-    puts "Updating identifier #{se_identifier.id}: #{se_identifier}"
-    res = StashEngine::Resource.where(identifier_id: se_identifier.id).order(created_at: :desc).first
-    if res.nil?
-      se_identifier.destroy! # useless orphan identifier with no contents which should be deleted
-    else
-      se_identifier.update!(latest_resource_id: res.id)
+  desc "Update identifiers latest resource if they don't have one"
+  task add_latest_resource: :environment do
+    StashEngine::Identifier.where(latest_resource_id: nil).each do |se_identifier|
+      puts "Updating identifier #{se_identifier.id}: #{se_identifier}"
+      res = StashEngine::Resource.where(identifier_id: se_identifier.id).order(created_at: :desc).first
+      if res.nil?
+        se_identifier.destroy! # useless orphan identifier with no contents which should be deleted
+      else
+        se_identifier.update!(latest_resource_id: res.id)
+      end
+    end
+  end
+
+  desc "Add searchable field contents for any identifiers missing it"
+  task add_search: :environment do
+    StashEngine::Identifier.where(search_words: nil).each do |se_identifier|
+      puts "Updating identifier #{se_identifier.to_s} for search"
+      se_identifier.update_search_words
     end
   end
 end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -139,6 +139,11 @@ module StashEngine
           @identifier2.reload
           # these are because travis won't run things correctly for some reason but works locally
           expect(@res5.id).to be_truthy
+          puts @res5.id
+          puts @identifier2.inspect
+          @identifier2.latest_resource_id = @res5.id
+          @identifier2.save
+          puts @identifier2.inspect
           expect(@identifier2.latest_resource_id).to be_truthy
           @identifier2.update_search_words!
           expect(@identifier2.search_words.strip).to eq('doi:10.123/450 Frolicks with the seahorses ' \

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -139,11 +139,9 @@ module StashEngine
           @identifier2.reload
           # these are because travis won't run things correctly for some reason but works locally
           expect(@res5.id).to be_truthy
-          puts @res5.id
-          puts @identifier2.inspect
+          # for some reason I have to do this again in here even though I did it already in before block for travis to work, but works locally
           @identifier2.latest_resource_id = @res5.id
           @identifier2.save
-          puts @identifier2.inspect
           expect(@identifier2.latest_resource_id).to be_truthy
           @identifier2.update_search_words!
           expect(@identifier2.search_words.strip).to eq('doi:10.123/450 Frolicks with the seahorses ' \

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -129,7 +129,8 @@ module StashEngine
         before(:each) do
           @identifier2 = Identifier.create(identifier_type: 'DOI', identifier: '10.123/450')
           @res5 = Resource.create(identifier_id: @identifier2.id, title: 'Frolicks with the seahorses')
-          @identifier2.update!(latest_resource_id: @res5.id)
+          @identifier2.latest_resource_id = @res5.id
+          @identifier2.save!
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: @res5.id)
           Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: @res5.id)
         end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -128,7 +128,7 @@ module StashEngine
       describe '#update_search_words!' do
         before(:each) do
           @identifier2 = Identifier.create(identifier_type: 'DOI', identifier: '10.123/450')
-          @res5 = Resource.create(identifier_id: identifier.id, title: 'Frolicks with the seahorses')
+          @res5 = Resource.create(identifier_id: @identifier2.id, title: 'Frolicks with the seahorses')
           @identifier2.update!(latest_resource_id: @res5.id)
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: @res5.id)
           Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: @res5.id)
@@ -136,6 +136,9 @@ module StashEngine
 
         it 'has concatenated all the search fields' do
           @identifier2.reload
+          # these are because travis won't run things correctly for some reason but works locally
+          expect(@res5.id).to be_truthy
+          expect(@identifier2.latest_resource_id).to be_truthy
           @identifier2.update_search_words!
           expect(@identifier2.search_words.strip).to eq('doi:10.123/450 Frolicks with the seahorses ' \
             'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -127,14 +127,16 @@ module StashEngine
 
       describe '#update_search_words!' do
         before(:each) do
+
+        end
+
+        it 'has concatenated all the search fields' do
           @identifier.update!(latest_resource_id: res3.id)
           @identifier.reload
           res3.update!(title: 'Frolicks with the seahorses')
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res3.id)
           Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res3.id)
-        end
 
-        it 'has concatenated all the search fields' do
           @identifier.reload
           expect(@identifier.search_words.strip).to eq('doi:10.123/456 Frolicks with the seahorses ' \
             'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -127,9 +127,8 @@ module StashEngine
 
       describe '#update_search_words!' do
         before(:each) do
-          @identifier.update(latest_resource_id: res3.id)
-          @identifier.reload
-          sleep(1) # what the hell is wrong with travis?
+          @identifier.update!(latest_resource_id: res3.id)
+          @identifier = Identifier.find(@identifier.id) # why won't travis reload this record?
           res = @identifier.latest_resource
           res.update(title: 'Frolicks with the seahorses')
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res.id)

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -128,11 +128,10 @@ module StashEngine
       describe '#update_search_words!' do
         before(:each) do
           @identifier.update!(latest_resource_id: res3.id)
-          @identifier = Identifier.find(@identifier.id) # why won't travis reload this record?
-          res = @identifier.latest_resource
-          res.update(title: 'Frolicks with the seahorses')
-          Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res.id)
-          Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res.id)
+          @identifier.reload
+          res3.update!(title: 'Frolicks with the seahorses')
+          Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res3.id)
+          Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res3.id)
         end
 
         it 'has concatenated all the search fields' do

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -137,7 +137,6 @@ module StashEngine
         it 'has concatenated all the search fields' do
           @identifier2.reload
           @identifier2.update_search_words!
-          @identifier2.reload
           expect(@identifier2.search_words.strip).to eq('doi:10.123/450 Frolicks with the seahorses ' \
             'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')
         end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -128,15 +128,14 @@ module StashEngine
       describe '#update_search_words!' do
         before(:each) do
           @identifier.update(latest_resource_id: res3.id)
+          @identifier.reload
           res = @identifier.latest_resource
           res.update(title: 'Frolicks with the seahorses')
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res.id)
           Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res.id)
-          @identifier.reload
         end
 
-        it 'concatenates all the search fields' do
-          @identifier.update_search_words!
+        it 'has concatenated all the search fields' do
           @identifier.reload
           expect(@identifier.search_words.strip).to eq('doi:10.123/456 Frolicks with the seahorses ' \
             'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -124,6 +124,24 @@ module StashEngine
           expect(resources.count).to eq(1)
         end
       end
+
+      describe '#update_search_words!' do
+        before(:each) do
+          @identifier.update(latest_resource_id: res3.id)
+          res = @identifier.latest_resource
+          res.update(title: 'Frolicks with the seahorses')
+          Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res.id)
+          Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res.id)
+          @identifier.reload
+        end
+
+        it 'concatenates all the search fields' do
+          @identifier.update_search_words!
+          @identifier.reload
+          expect(@identifier.search_words.strip).to eq('doi:10.123/456 Frolicks with the seahorses ' \
+            'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')
+        end
+      end
     end
   end
 end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -127,18 +127,16 @@ module StashEngine
 
       describe '#update_search_words!' do
         before(:each) do
-
-        end
-
-        it 'has concatenated all the search fields' do
-          @identifier.update!(latest_resource_id: res3.id)
-          @identifier.reload
+          identifier.update!(latest_resource_id: res3.id)
+          identifier.reload
           res3.update!(title: 'Frolicks with the seahorses')
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res3.id)
           Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res3.id)
+        end
 
-          @identifier.reload
-          expect(@identifier.search_words.strip).to eq('doi:10.123/456 Frolicks with the seahorses ' \
+        it 'has concatenated all the search fields' do
+          identifier.reload
+          expect(identifier.search_words.strip).to eq('doi:10.123/456 Frolicks with the seahorses ' \
             'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')
         end
       end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -127,16 +127,18 @@ module StashEngine
 
       describe '#update_search_words!' do
         before(:each) do
-          identifier.update!(latest_resource_id: res3.id)
-          identifier.reload
-          res3.update!(title: 'Frolicks with the seahorses')
-          Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res3.id)
-          Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: res3.id)
+          @identifier2 = Identifier.create(identifier_type: 'DOI', identifier: '10.123/450')
+          @res5 = Resource.create(identifier_id: identifier.id, title: 'Frolicks with the seahorses')
+          @identifier2.update!(latest_resource_id: @res5.id)
+          Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: @res5.id)
+          Author.create(author_first_name: 'Marcus', author_last_name: 'Lee', author_orcid: '88-11-1138-2233', resource_id: @res5.id)
         end
 
         it 'has concatenated all the search fields' do
-          identifier.reload
-          expect(identifier.search_words.strip).to eq('doi:10.123/456 Frolicks with the seahorses ' \
+          @identifier2.reload
+          @identifier2.update_search_words!
+          @identifier2.reload
+          expect(@identifier2.search_words.strip).to eq('doi:10.123/450 Frolicks with the seahorses ' \
             'Joanna Jones  33-22-4838-3322 Marcus Lee  88-11-1138-2233')
         end
       end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -129,6 +129,7 @@ module StashEngine
         before(:each) do
           @identifier.update(latest_resource_id: res3.id)
           @identifier.reload
+          sleep(1) # what the hell is wrong with travis?
           res = @identifier.latest_resource
           res.update(title: 'Frolicks with the seahorses')
           Author.create(author_first_name: 'Joanna', author_last_name: 'Jones', author_orcid: '33-22-4838-3322', resource_id: res.id)


### PR DESCRIPTION
This PR incorporates code from the previous PR since they build on each other. 

This enables a javascript modal dialog for changing the status from the admin chart like shown at http://ux.cdlib.org/jlee/completed/dryad_03oct2018/#g=1&p=admin_dashboard_v2 .  (click the pencil under status in the wireframe.)

It sounds like we'll have a meeting about status workflow early next week ahead of our next sprint to iron out more details of how it would work in other areas.