### PR TITLE
Tweaks for migrating provenances

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -37,6 +37,7 @@ module StashApi
       params.permit!
       @curation_activity = StashEngine::CurationActivity.new(params[:curation_activity].except(:identifier_id, :user_id, :dataset))
       @curation_activity.update!(user_id: @user.id, identifier_id: @stash_identifier.id)
+      @curation_activity.update!(user_id: nil) if params[:user_id].nil?
       render json: @curation_activity
     end
 
@@ -45,6 +46,7 @@ module StashApi
       params.permit!
       @curation_activity = StashEngine::CurationActivity.find(params[:id])
       @curation_activity.update!(params[:curation_activity].except(:identifier_id, :user_id, :dataset))
+      @curation_activity.update!(user_id: nil) if params[:user_id].nil?
       respond_to do |format|
         format.json { render json: @curation_activity }
       end

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -31,7 +31,7 @@ module StashEngine
         id: id,
         dataset: stash_identifier.to_s,
         status: status,
-        action_taken_by: user.name,
+        action_taken_by: user_name,
         note: note,
         keywords: keywords,
         created_at: created_at,
@@ -46,6 +46,11 @@ module StashEngine
       return if stash_identifier.nil?
       return if stash_identifier.identifier_state.nil?
       stash_identifier.identifier_state.update_identifier_state(self)
+    end
+
+    def user_name
+      return user.name unless user.nil?
+      'System'
     end
   end
 end

--- a/stash_engine/app/models/stash_engine/identifier_state.rb
+++ b/stash_engine/app/models/stash_engine/identifier_state.rb
@@ -11,7 +11,7 @@ module StashEngine
 
     def update_identifier_state(c_a)
       return if c_a.status.equal?('Status Unchanged')
-      return if c_a.created_at < curation_activity.created_at
+      return if !curation_activity.nil? && c_a.created_at < curation_activity.created_at
       update(curation_activity: c_a, current_curation_status: c_a.status)
     end
   end

--- a/stash_engine/app/models/stash_engine/identifier_state.rb
+++ b/stash_engine/app/models/stash_engine/identifier_state.rb
@@ -10,6 +10,8 @@ module StashEngine
     end
 
     def update_identifier_state(c_a)
+      return if c_a.status.equal?('Status Unchanged')
+      return if c_a.created_at < curation_activity.created_at
       update(curation_activity: c_a, current_curation_status: c_a.status)
     end
   end

--- a/stash_engine/db/migrate/20181203191849_change_curation_activity_note_to_text.rb
+++ b/stash_engine/db/migrate/20181203191849_change_curation_activity_note_to_text.rb
@@ -1,0 +1,5 @@
+class ChangeCurationActivityNoteToText < ActiveRecord::Migration
+  def change
+    change_column :stash_engine_curation_activities, :note, :text
+  end
+end


### PR DESCRIPTION
When migrating older provenance messages, make sure they don’t unnecessarily change the current curation state.

In addition, if there isn’t a user specified for a curation activity, return “System”.