### PR TITLE
Enable file upload

### DIFF
--- a/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -83,7 +83,8 @@ module StashDatacite
       resource.update_publication_date!
       resource.save
 
-      resource.update(skip_datacite_update: false, skip_emails: false, loosen_validation: false) # these are only for API superusers to choose
+      # TODO: when we revise the way we submit to DataCite, remove this.  Until then it just causes occasional errors
+      resource.update(skip_datacite_update: false, skip_emails: false, loosen_validation: false) # these are mostly for API superusers to choose
 
       # TODO: put this somewhere more reliable
       StashDatacite::DataciteDate.set_date_available(resource_id: resource.id)

--- a/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -84,7 +84,7 @@ module StashDatacite
       resource.save
 
       # TODO: when we revise the way we submit to DataCite, remove this.  Until then it just causes occasional errors
-      resource.update(skip_datacite_update: false, skip_emails: false, loosen_validation: false) # these are mostly for API superusers to choose
+      resource.update(skip_datacite_update: true, skip_emails: false, loosen_validation: false) # these are mostly for API superusers to choose
 
       # TODO: put this somewhere more reliable
       StashDatacite::DataciteDate.set_date_available(resource_id: resource.id)

--- a/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -63,13 +63,8 @@
     <%= render partial: "stash_datacite/licenses/review" %>
 
 <div class="o-dataset-nav">
-  <% if current_user.id == @resource.user_id %>
-    <%= link_to 'Back to Upload Files', stash_url_helpers.upload_resource_path(@resource), id: 'dashboard_path',
-              class: 'o-button__icon-left', role: 'button' %>
-  <% else %>
-    <%= link_to 'Back to Describe Dataset', stash_url_helpers.metadata_entry_pages_find_or_create_path(resource_id: params[:id]),
-                class: 'o-button__icon-left', role: 'button', id: 'describe_back' %>
-  <% end %>
+  <%= link_to 'Back to Upload Files', stash_url_helpers.upload_resource_path(@resource), id: 'dashboard_path',
+            class: 'o-button__icon-left', role: 'button' %>
 
   <% if @data.blank? # valid data %>
     <%= form_tag stash_datacite.resources_submission_path do -%>

--- a/stash_engine/app/views/stash_engine/shared/_dataset_steps_bottom_nav.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_dataset_steps_bottom_nav.html.erb
@@ -4,9 +4,5 @@
 </div>
 <div class="o-dataset-nav">
   <%= link_to 'Back to My Datasets', stash_engine.dashboard_path , id: 'dashboard_path', class: 'o-button__icon-left', role: 'button' %>
-  <% if current_user.id == @resource.user_id %>
-    <%= link_to 'Proceed to Upload', stash_engine.upload_resource_path(@resource), id: 'upload_path', class: 'o-button__icon-right', role: 'button' %>
-  <% else %>
-    <%= link_to 'Proceed to Review', stash_engine.review_resource_path(params[:resource_id]), class: 'o-button__icon-right', role: 'button', id: 'proceed_review' %>
-  <% end %>
+  <%= link_to 'Proceed to Upload', stash_engine.upload_resource_path(@resource), id: 'upload_path', class: 'o-button__icon-right', role: 'button' %>
 </div>

--- a/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
@@ -2,13 +2,9 @@
   <%= link_to 'Describe Dataset', {controller: 'metadata_entry_pages', action: 'find_or_create', resource_id: @resource.id},
               class: "c-progress__tab1#{ (params[:controller].end_with?('metadata_entry_pages') && params[:action] == 'find_or_create' ? '--active' : '' )}" %>
 
-  <% if current_user.id != @resource.user_id %>
-    <div class="c-progress__tab2--inactive">Upload Files</div>
-  <% else %>
-    <%= link_to 'Upload Files', stash_engine.upload_resource_path(@resource.id),
-              class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action] == 'upload' ? '--active' : '') }" %>
-  <% end %>
-  
+  <%= link_to 'Upload Files', stash_engine.upload_resource_path(@resource.id),
+            class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action] == 'upload' ? '--active' : '') }" %>
+
   <%= link_to 'Review and Submit', stash_engine.review_resource_path(@resource.id),
               class: "c-progress__tab3#{ (params[:controller].end_with?('resources') && params[:action] == 'review' ? '--active' : '') }" %>
 </div>

--- a/stash_engine/spec/unit/models/tenant_spec.rb
+++ b/stash_engine/spec/unit/models/tenant_spec.rb
@@ -112,7 +112,7 @@ module StashEngine
         tenant = Tenant.by_domain('example.edu')
         Dir.mktmpdir('rails_root') do |rails_root|
           allow(Rails).to receive(:root).and_return(rails_root)
-          expect(tenant.logo_file).to eq(Tenant::DEFAULT_LOGO_FILE)
+          expect(tenant.logo_file).to eq('') # no longer want to display a default and ignored by ui code if unavailable
         end
       end
     end


### PR DESCRIPTION
This allows curators to view and edit the files attached to a dataset.  These are mostly simple UI changes to change navigation options.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/115

I added code so things are not updated to DataCite because it all fails with multiple versions after they delete them and they are soon getting ride of test identifiers, anyway.

The updates to DataCite will be moved to the embargo setting or publication step in curation status, anyway, and not tied to submission, so this will all be changed or gutted soon.

