### PR TITLE
Prepopulation of manuscript data

### DIFF
--- a/stash_datacite/Gemfile
+++ b/stash_datacite/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'byebug', group: %i[development test]
+gem 'httparty'
 gem 'mysql2', '< 0.5x', '>= 0.3.13'
 gem 'parallel_tests', group: %i[development test]
 

--- a/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -1,0 +1,83 @@
+function loadPublications() {
+    // based on example at http://jqueryui.com/autocomplete/#remote-jsonp
+    $(function() {
+        function split( val ) {
+            return val.split( /,\s*/ );
+        }
+        function extractLast( term ) {
+            return split( term ).pop();
+        }
+
+        $( ".js-publications" )
+        // don't navigate away from the field on tab when selecting an item
+            .bind( "keydown", function( event ) {
+                if ( event.keyCode === $.ui.keyCode.TAB &&
+                    $( this ).autocomplete( "instance" ).menu.active ) {
+                    event.preventDefault();
+                }
+            })
+            .autocomplete({
+                create: function(a) {
+                    $.ajax({
+                        url: "https://api.crossref.org/journals/"+ document.getElementById("internal_datum_publication_name").value,
+                        dataType: "json",
+                        success: function( data ) {
+                            document.getElementById("internal_datum_publication_name").value = ""
+                            if (data.message.title != null) {
+                                document.getElementById("internal_datum_publication_name").value = data.message.title;
+                            }
+                        }
+                    });
+                },
+                source: function( request, response ) {
+                    $.ajax({
+                        url: "https://api.crossref.org/journals?query="+ extractLast( request.term ),
+                        dataType: "json",
+                        success: function( data ) {
+                            $.ajax({
+                                url: "https://api.crossref.org/journals?query="+ extractLast( request.term ) + "&rows=" + data.message["total-results"],
+                                dataType: "json",
+                                success: function( data ) {
+                                    var arr = jQuery.map( data.message.items, function( a ) {
+                                        return [[ a.ISSN[0], a.title ]];
+                                    });
+                                    var labels = [];
+                                    $.each(arr, function(index, value) {
+                                        if (value[0] != null) {
+                                            labels.push({value: value[0], label: value[1]});
+                                        }
+                                    });
+                                    response(labels);
+                                }
+                            });
+                        }
+                    });
+                },
+                minLength: 3,
+                select: function( event, ui ) {
+                    new_value = ui.item.value;
+                    document.getElementById("internal_datum_publication_issn").value = new_value;
+                    ui.item.value = ui.item.label;
+                    var form = $(this.form);
+                    $(form).trigger('submit.rails');
+                    previous_value = new_value;
+                },
+                focus: function() {
+                    // prevent value inserted on focus
+                    return false;
+                },
+            });
+    });
+
+    $( '.js-publications' ).on('focus', function () {
+        previous_value = this.value;
+        // console.log('previous value:' + previous_value );
+    }).change(function() {
+        new_value = this.value;
+        // Save when the new value is different from the previous value
+        if(new_value != previous_value) {
+            var form = $(this.form);
+            $(form).trigger('submit.rails');
+        }
+    });
+};

--- a/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -69,7 +69,7 @@ function loadPublications() {
             });
     });
 
-    $( '.js-publications' ).on('focus', function () {
+    $( '.js-msid' ).on('focus', function () {
         previous_value = this.value;
         // console.log('previous value:' + previous_value );
     }).change(function() {

--- a/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -11,6 +11,8 @@ module StashDatacite
       @publication = StashEngine::InternalDatum.find_by(stash_identifier: se_id, data_type: 'publicationISSN')
       @publication = StashEngine::InternalDatum.new(stash_identifier: se_id, data_type: 'publicationISSN') if @publication.nil?
 
+      @msid = StashEngine::InternalDatum.find_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
+      @msid = StashEngine::InternalDatum.new(stash_identifier: se_id, data_type: 'manuscriptNumber') if @msid.nil?
       respond_to do |format|
         format.js
       end

--- a/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -7,6 +7,10 @@ module StashDatacite
     def find_or_create
       @metadata_entry = Resource::MetadataEntry.new(@resource, current_tenant)
       @metadata_entry.resource_type
+      se_id = StashEngine::Identifier.find(@resource.identifier_id)
+      @publication = StashEngine::InternalDatum.find_by(stash_identifier: se_id, data_type: 'publicationISSN')
+      @publication = StashEngine::InternalDatum.new(stash_identifier: se_id, data_type: 'publicationISSN') if @publication.nil?
+
       respond_to do |format|
         format.js
       end

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -9,8 +9,11 @@ module StashDatacite
       @pub_issn = StashEngine::InternalDatum.find_by(stash_identifier: @se_id, data_type: 'publicationISSN')
       @pub_issn = StashEngine::InternalDatum.new(stash_identifier: @se_id, data_type: 'publicationISSN') if @pub_issn.nil?
 
+      @msid = StashEngine::InternalDatum.find_by(stash_identifier: @se_id, data_type: 'manuscriptNumber')
+      @msid = StashEngine::InternalDatum.new(stash_identifier: @se_id, data_type: 'manuscriptNumber') if @msid.nil?
       respond_to do |format|
         format.js { render template: 'stash_datacite/shared/update.js.erb' } if @pub_issn.update(value: params[:internal_datum][:publication_issn])
+        format.js { render template: 'stash_datacite/shared/update.js.erb' } if @msid.update(value: params[:internal_datum][:msid])
       end
     end
 

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -1,0 +1,20 @@
+require_dependency 'stash_datacite/application_controller'
+
+module StashDatacite
+  class PublicationsController < ApplicationController
+
+    # PATCH/PUT /publications/1
+    def update
+      @se_id = StashEngine::Identifier.find(params[:internal_datum][:identifier_id])
+      @pub_issn = StashEngine::InternalDatum.find_by(stash_identifier: @se_id, data_type: 'publicationISSN')
+      @pub_issn = StashEngine::InternalDatum.new(stash_identifier: @se_id, data_type: 'publicationISSN') if @pub_issn.nil?
+
+      respond_to do |format|
+        format.js { render template: 'stash_datacite/shared/update.js.erb' } if @pub_issn.update(value: params[:internal_datum][:publication_issn])
+      end
+    end
+
+    private
+  end
+end
+

--- a/stash_datacite/app/models/stash_datacite/publication.rb
+++ b/stash_datacite/app/models/stash_datacite/publication.rb
@@ -1,0 +1,6 @@
+module StashDatacite
+  class Publication < ActiveRecord::Base
+    self.table_name = 'stash_engine_internal_data'
+    belongs_to :stash_identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
+  end
+end

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -6,6 +6,9 @@
 </div>
 
 <h3 class="o-heading__page-span">Basic Information</h3>
+  <div class="js-contributors_form">
+    <%= render partial: "stash_datacite/metadata_entry_pages/publication", locals: { publication: @publication, resource: @resource } %>
+  </div>
 
   <%= render partial: "stash_datacite/titles/form", locals: { resource: @resource } %><br/>
 

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -3,6 +3,7 @@
 		<%= f.label "journal_name", 'Journal Name', class: 'c-input__label' %>
 		<%= f.text_field :publication_name, value: @publication.value, class: "js-publications c-input__text" %>
     <%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
+    <%= f.hidden_field :resource_id, value: @resource.id %>
     <%= f.hidden_field :publication_issn, value: @publication.value %>
   </div>
   <div class="c-input">
@@ -10,3 +11,4 @@
     <%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text" %>
   </div>
 <% end %>
+<%= link_to "Add Manuscript Metadata", publications_autofill_data_path( id: @resource.id ), method: :post, class: 'o-button__add' %>

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -1,0 +1,8 @@
+<%= form_for(@publication, url: publications_update_path, method: :patch, remote: true, authenticity_token: true, html: { class: 'c-input__inline' }) do |f| %>
+	<div class="c-input">
+		<%= f.label "journal_name", 'Journal Name', class: 'c-input__label' %>
+		<%= f.text_field :publication_name, value: @publication.value, class: "js-publications c-input__text" %>
+    <%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
+    <%= f.hidden_field :publication_issn, value: @publication.value %>
+  </div>
+<% end %>

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -5,4 +5,8 @@
     <%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
     <%= f.hidden_field :publication_issn, value: @publication.value %>
   </div>
+  <div class="c-input">
+    <%= f.label "msid", 'Manuscript Number', class: 'c-input__label' %>
+    <%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text" %>
+  </div>
 <% end %>

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.html.erb
@@ -10,6 +10,7 @@ $(function() {
   hideRemoveRequiredLabelAuthors();
   loadDescriptions();
   loadContributors();
+  loadPublications();
   hideRemoveLinkContributors();
   loadSubjects();
   loadRelatedIdentifiers();

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.js.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/find_or_create.js.erb
@@ -6,6 +6,7 @@ loadAuthors();
 hideRemoveLinkAuthors();
 hideRemoveRequiredLabelAuthors()
 loadContributors();
+loadPublications();
 hideRemoveLinkContributors();
 loadDescriptions();
 loadSubjects();

--- a/stash_datacite/config/routes.rb
+++ b/stash_datacite/config/routes.rb
@@ -20,6 +20,11 @@ StashDatacite::Engine.routes.draw do
   patch 'contributors/update', to: 'contributors#update'
   delete 'contributors/:id/delete', to: 'contributors#delete', as: 'contributors_delete'
 
+  get 'publications/new', to: 'publications#new'
+  post 'publications/create', to: 'publications#create'
+  patch 'publications/update', to: 'publications#update'
+  delete 'publications/:id/delete', to: 'publications#delete', as: 'publications_delete'
+
   get 'resource_types/new', to: 'resource_types#new'
   post 'resource_types/create', to: 'resource_types#create'
   patch 'resource_types/update', to: 'resource_types#update'

--- a/stash_datacite/config/routes.rb
+++ b/stash_datacite/config/routes.rb
@@ -24,6 +24,7 @@ StashDatacite::Engine.routes.draw do
   post 'publications/create', to: 'publications#create'
   patch 'publications/update', to: 'publications#update'
   delete 'publications/:id/delete', to: 'publications#delete', as: 'publications_delete'
+  post 'publications/autofill/:id', to: 'publications#autofill_data', as: 'publications_autofill_data'
 
   get 'resource_types/new', to: 'resource_types#new'
   post 'resource_types/create', to: 'resource_types#create'


### PR DESCRIPTION
Adds three main chunks of functionality:
1) Creates fields on the Describe Dataset page for entering the journal and manuscript number, if available. These get added as internal data fields with data_type "publicationISSN" and "manuscriptNumber."

2) Sets up autocomplete on the journal field, so that you can type in a journal name instead of an ISSN and a list of matching journals with ISSNs is pulled from Crossref, and while the name is displayed to the user, the ISSN is internally stored in the internal data field.

This feature is a bit slow because Crossref's API is really minimal for the /journals query endpoint. It doesn't give you any good way to discover the match score or tweak the result order in any way, so basically I had to set it up to make two calls: one to find out how many results there are, then another to return all the matched results. The resulting list can be very long for a short search string like "Cell," but there's no other way to guarantee that a short journal name will be in the results. Someone else can hook into this later and do some kind of sorting to return a smaller list if necessary.

3) Added the "Add Manuscript Metadata" button. If the ISSN/Manuscript Number combination is available in the Dryad Classic journal integration system, the dataset is prepopulated with the metadata from that manuscript, overwriting whatever was there before. This works via PUT, so even if you change the manuscript number and journal name and then redo it, you'll repopulate the metadata over again. It doesn't change anything if the metadata isn't available. 

I have everything working on the dev server:
- Go to dryad-dev and log in
- Create a new dataset
- Choose “Applications in Plant” and watch the autofill (it takes a sec) and choose “Applications in Plant Sciences”
- Enter APPS-D-17-00113 as the manuscript number
- Hit the “Add Manuscript Metadata” button

The package page should refresh with the new metadata prepopulated.