### PR TITLE
Merging in changes made to Dash into Dryad

### DIFF
--- a/stash-wrapper/CHANGES.md
+++ b/stash-wrapper/CHANGES.md
@@ -1,10 +1,10 @@
-# 0.1.12 (next)
+# 0.1.12 (14 November 2018)
 
 - Change stash-wrapper namespace URI to https://dash.ucop.edu/stash_wrapper/ and schema location to 
   https://dash.ucop.edu/stash_wrapper/stash_wrapper.xsd (formerly both URLs were http://dash.cdlib.org/)
-- Update to Ruby 2.2.5
-- Update to Rubocop 0.49
-
+- Update to Ruby 2.4.1
+- Update to Rubocop 0.57.2
+- Update dependencies
 
 # 0.1.11.1 (5 August 2016)
 

--- a/stash-wrapper/LICENSE.md
+++ b/stash-wrapper/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 The Regents of the University of California
+Copyright (c) 2018 The Regents of the University of California
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/stash_engine/app/assets/javascripts/stash_engine/metadata_entry_pages.js
+++ b/stash_engine/app/assets/javascripts/stash_engine/metadata_entry_pages.js
@@ -1,24 +1,36 @@
-$(function () {
-  // only attach these events on metadata entry pages
-  if($('body.metadata_entry_pages_find_or_create').length < 1){
-    return;
-  }
-  $('a').click(function(){
-    $.ajax({
-      type: 'GET',
-      async: false,
-      url: '/stash/ajax_wait'
-    });
-    waitAjax();
-  });
-});
+function trapNavigation() {
+    $(function () {
+        // only attach these events on metadata entry pages
+        if ($('body.metadata_entry_pages_find_or_create').length < 1) {
+            return;
+        }
 
-// blocks until all ajax connections are closed
-var waitAjax = function(){
-  if($.active < 1){
-    return;
-  }
-  else {
-    setTimeout(waitAjax, 100); // check again in 100 ms
-  }
+        // blocks until all ajax connections are closed
+        var waitAjax = function () {
+            // apparantly this changes with versions of jQuery
+            if (( $.ajax.active === undefined ? $.active : $.ajax.active) < 1) {
+                return;
+            } else {
+                setTimeout(waitAjax, 100); // check again in 100 ms
+            }
+        }
+
+        /* trap the click event for the simple links that navigate away (have .js-nav-out class), wait briefly,
+        wait for any ajax to stop, and then navigate manually with the window.location. */
+        $('.js-nav-out').on('click', function(e) {
+            e.preventDefault();
+            my_target = e.target.href;
+
+            setTimeout(
+                function(e) {
+                    // alert( my_target );
+                    waitAjax();
+                    window.location = my_target;
+                }, 500);
+        });
+    });
 }
+
+// see https://stackoverflow.com/questions/7610871/how-to-trigger-an-event-after-using-event-preventdefault
+// may need to use in the future.
+

--- a/stash_engine/app/assets/javascripts/stash_engine/ui.js
+++ b/stash_engine/app/assets/javascripts/stash_engine/ui.js
@@ -531,11 +531,13 @@ $(document).ready(function(){
         // $('details div.o-sites__group').show();
         modernizeIt();
         joelsReady();
+        trapNavigation();
         $(this).unbind("ajaxStop"); // required since it fires everytime ajax stops after that, otherwise!
       });
     }else{
       modernizeIt();
       joelsReady();
+      trapNavigation();
     }
   }, 30);
 });

--- a/stash_engine/app/models/stash_engine/user.rb
+++ b/stash_engine/app/models/stash_engine/user.rb
@@ -53,7 +53,9 @@ module StashEngine
     end
 
     def self.split_name(name)
-      first = name.split(' ').first
+      comma_split = name.split(',')
+      return [comma_split[1].strip, comma_split[0].strip] if comma_split.length == 2 # gets a reversed name with comma like "Janee, Greg"
+      first = (name.split(' ').first || '').strip
       last = ''
       last = name.split(' ').last unless name.split(' ').last == first
       [first, last]

--- a/stash_engine/app/views/layouts/stash_engine/application.html.erb
+++ b/stash_engine/app/views/layouts/stash_engine/application.html.erb
@@ -28,7 +28,7 @@
   <% end %>
     <div class="c-header__logos">
       <button aria-label="mobile menu" class="o-button__menu c-header__menu-button js-header__menu-button"></button>
-      <%= link_to(stash_url_helpers.root_path, class: 'c-header__dash-logo-link') do %>
+      <%= link_to(stash_url_helpers.root_path, class: 'c-header__dash-logo-link js-nav-out') do %>
         <%
           dash_logo = image_tag('stash_engine/logo_dryad.png', class: 'c-header__dash-logo-svg', alt: 'Dash logo')
         tenant_logo = ( current_tenant.logo_file.blank? ? '' : logo_path(class: "c-header__dash-logo-svg") ) %>
@@ -52,10 +52,10 @@
                       class: 'c-header__nav-item' %>
         <% end %>
         <%# link_to 'Home', stash_url_helpers.root_path, class: 'c-header__nav-item' %>
-        <%= link_to 'Explore Data', '/search', class: 'c-header__nav-item' %>
-        <%= link_to 'Help', stash_url_helpers.help_path, class: 'c-header__nav-item' %>
+        <%= link_to 'Explore Data', '/search', class: 'c-header__nav-item js-nav-out' %>
+        <%= link_to 'Help', stash_url_helpers.help_path, class: 'c-header__nav-item js-nav-out' %>
         <% if current_user %>
-          <%= link_to 'My Datasets', stash_url_helpers.dashboard_path, class: 'c-header__nav-item' %>
+          <%= link_to 'My Datasets', stash_url_helpers.dashboard_path, class: 'c-header__nav-item js-nav-out' %>
         <% end %>
         <%= render partial: 'stash_engine/shared/log_in_out' %>
         <%# render partial: "stash_engine/shared/sites" %>

--- a/stash_engine/app/views/stash_engine/dashboard/ajax_wait.js.erb
+++ b/stash_engine/app/views/stash_engine/dashboard/ajax_wait.js.erb
@@ -1,0 +1,1 @@
+// alert('Did an ajax wait');

--- a/stash_engine/app/views/stash_engine/shared/_dataset_steps_bottom_nav.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_dataset_steps_bottom_nav.html.erb
@@ -3,6 +3,6 @@
   <div class="c-autosave__text saved_text" style="display: none;">All Progress Saved.</div>
 </div>
 <div class="o-dataset-nav">
-  <%= link_to 'Back to My Datasets', stash_engine.dashboard_path , id: 'dashboard_path', class: 'o-button__icon-left', role: 'button' %>
-  <%= link_to 'Proceed to Upload', stash_engine.upload_resource_path(@resource), id: 'upload_path', class: 'o-button__icon-right', role: 'button' %>
+  <%= link_to 'Back to My Datasets', stash_engine.dashboard_path , id: 'dashboard_path', class: 'o-button__icon-left js-nav-out', role: 'button' %>
+  <%= link_to 'Proceed to Upload', stash_engine.upload_resource_path(@resource), id: 'upload_path', class: 'o-button__icon-right js-nav-out', role: 'button' %>
 </div>

--- a/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_dataset_steps_nav.html.erb
@@ -1,10 +1,10 @@
 <div class="c-progress">
   <%= link_to 'Describe Dataset', {controller: 'metadata_entry_pages', action: 'find_or_create', resource_id: @resource.id},
-              class: "c-progress__tab1#{ (params[:controller].end_with?('metadata_entry_pages') && params[:action] == 'find_or_create' ? '--active' : '' )}" %>
+              class: "c-progress__tab1#{ (params[:controller].end_with?('metadata_entry_pages') && params[:action] == 'find_or_create' ? '--active' : '' )} js-nav-out" %>
 
   <%= link_to 'Upload Files', stash_engine.upload_resource_path(@resource.id),
-            class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action] == 'upload' ? '--active' : '') }" %>
+            class: "c-progress__tab2#{ (params[:controller].end_with?('resources') && params[:action] == 'upload' ? '--active' : '') } js-nav-out" %>
 
   <%= link_to 'Review and Submit', stash_engine.review_resource_path(@resource.id),
-              class: "c-progress__tab3#{ (params[:controller].end_with?('resources') && params[:action] == 'review' ? '--active' : '') }" %>
+              class: "c-progress__tab3#{ (params[:controller].end_with?('resources') && params[:action] == 'review' ? '--active' : '') } js-nav-out" %>
 </div>

--- a/stash_engine/app/views/stash_engine/shared/_footer.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_footer.html.erb
@@ -1,14 +1,14 @@
 <footer class="c-footer">
   <div class="c-footer__link-group">
     <div class="c-footer__nav-group">
-      <%= link_to 'Explore Data', '/search', class: 'c-footer__nav-item' %>
-      <%= link_to 'About Dash', stash_url_helpers.about_path, class: 'c-footer__nav-item' %>
+      <%= link_to 'Explore Data', '/search', class: 'c-footer__nav-item js-nav-out' %>
+      <%= link_to 'About Dash', stash_url_helpers.about_path, class: 'c-footer__nav-item js-nav-out' %>
       <% if current_user %>
-        <%= link_to 'My Datasets', stash_url_helpers.dashboard_path, class: 'c-footer__nav-item' %>
+        <%= link_to 'My Datasets', stash_url_helpers.dashboard_path, class: 'c-footer__nav-item js-nav-out' %>
         <!-- Logout -->
-        <%= link_to 'Logout', stash_url_helpers.sessions_destroy_path, class: 'c-footer__nav-item' %>
+        <%= link_to 'Logout', stash_url_helpers.sessions_destroy_path, class: 'c-footer__nav-item js-nav-out' %>
       <% else %>
-        <%= link_to 'Login', stash_url_helpers.choose_login_path, class: 'c-footer__nav-item' %>
+        <%= link_to 'Login', stash_url_helpers.choose_login_path, class: 'c-footer__nav-item js-nav-out' %>
         <div class="c-footer__logged-in-or-out">
           <div class="o-sites">
             <details class="o-showhide o-sites__details" role="group">
@@ -22,14 +22,15 @@
           </div>
         </div>
       <% end %>
-      <%= link_to 'Help', stash_url_helpers.help_path, class: 'c-footer__nav-item' %>
+      <%= link_to 'Help', stash_url_helpers.help_path, class: 'c-footer__nav-item js-nav-out' %>
     </div>
     <div class="c-footer__policy-group">
-      <a href="http://www.cdlib.org/about/terms.html">Terms of Use</a>
-      <a href="http://www.cdlib.org/about/privacy.html">Privacy Policy</a>
-      <a href="http://www.cdlib.org/about/accessibility.html">Accessibility Policy</a>
+      <a href="http://www.cdlib.org/about/terms.html" class="js-nav-out">Terms of Use</a>
+      <a href="http://www.cdlib.org/about/privacy.html" class="js-nav-out">Privacy Policy</a>
+      <a href="http://www.cdlib.org/about/accessibility.html" class="js-nav-out">Accessibility Policy</a>
     </div>
   </div>
-  <p>Dash is a collaborative project between your UC campus and <a href="http://www.cdlib.org" class="o-link__primary">California Digital Library</a></p>
+  <p>Dash is a collaborative project between your UC campus and
+    <a href="http://www.cdlib.org" class="o-link__primary js-nav-out">California Digital Library</a></p>
   <p>© The Regents of the University of California</p>
 </footer>

--- a/stash_engine/app/views/stash_engine/shared/_log_in_out.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_log_in_out.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
-  <%= link_to 'Logout', stash_url_helpers.sessions_destroy_path, class: 'c-header__nav-item' %>
+  <%= link_to 'Logout', stash_url_helpers.sessions_destroy_path, class: 'c-header__nav-item js-nav-out' %>
 <% else %>
-  <%= link_to 'Login', stash_url_helpers.choose_login_path, class: 'c-header__nav-item' %>
+  <%= link_to 'Login', stash_url_helpers.choose_login_path, class: 'c-header__nav-item js-nav-out' %>
 <% end %>


### PR DESCRIPTION
These are mostly changes made to make saving of the Abstract more reliable in the UI, especially when using Apple Safari where it had problems more often.  To test, fill in an abstract and then click the "next page" button at the bottom without clicking outside the abstract first.

The Javascript changes explicitly add css classes for javascript attachment to links that will navigate off page.  The attached script then delays, allowing AJAX to start and then checks jQuery AJAX request counts on a timer until count goes to 0 before going to the new URL.

It looks like some release notes were changed by David M sometime in Dash, also.

