### PR TITLE
Allowing Tab Separated Value download for Excel

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -16,8 +16,11 @@ module StashEngine
       my_tenant_id = (current_user.role == 'admin' ? current_user.tenant_id : nil)
       @all_stats = Stats.new
       @seven_day_stats = Stats.new(tenant_id: my_tenant_id, since: (Time.new - 7.days))
-
       @ds_identifiers = build_table_query
+      respond_to do |format|
+        format.html
+        format.tsv
+      end
     end
 
     # Unobtrusive Javascript (UJS) to do AJAX by running javascript

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -102,7 +102,11 @@ module StashEngine
       # It doesn't really support sorting by relevance because of the other sorts.
       ds_identifiers = ds_identifiers.where('MATCH(search_words) AGAINST(?) > 0.5', params[:q]) unless params[:q].blank?
       ds_identifiers = add_filters(query_obj: ds_identifiers)
-      ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)
+      if request.format.tsv?
+        ds_identifiers.order(@sort_column.order).page(1).per(2_000)
+      else
+        ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)
+      end
     end
 
     def base_table_join

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -65,6 +65,11 @@ module StashEngine
     private
 
     def setup_paging
+      if request.format.tsv?
+        @page = 1
+        @page_size = 2_000
+        return
+      end
       @page = params[:page] || '1'
       @page_size = (params[:page_size].blank? || params[:page_size] != '1000000' ? '10' : '1000000')
     end
@@ -102,11 +107,7 @@ module StashEngine
       # It doesn't really support sorting by relevance because of the other sorts.
       ds_identifiers = ds_identifiers.where('MATCH(search_words) AGAINST(?) > 0.5', params[:q]) unless params[:q].blank?
       ds_identifiers = add_filters(query_obj: ds_identifiers)
-      if request.format.tsv?
-        ds_identifiers.order(@sort_column.order).page(1).per(2_000)
-      else
-        ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)
-      end
+      ds_identifiers.order(@sort_column.order).page(@page).per(@page_size)
     end
 
     def base_table_join

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -15,7 +15,7 @@
   </div>
 
   <div>
-    <%= link_to 'Get Tab Separated Values (for Excel)', params.merge(format: :tsv) %>
+    <%= link_to 'Get Tab Separated Values (TSV) for import into Excel', params.merge(format: :tsv) %>
   </div>
 </div>
 

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -13,6 +13,10 @@
   <div class="c-space-paginator">
     <%= paginate @ds_identifiers, params: { page_size: @page_size, show_all: false } %>
   </div>
+
+  <div>
+    <%= link_to 'Get Tab Separated Values (for Excel)', params.merge(format: :tsv) %>
+  </div>
 </div>
 
 <div id="popup_dialog" style="display:none;">

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.tsv.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.tsv.erb
@@ -1,0 +1,7 @@
+<%= "Title\tStatus\tAuthor(s)\tDOI\tLast modified\tLast modified by\tSize\tPublication date" %>
+<% @ds_identifiers.each do |i| %>
+  <% # nothing
+  -%>
+  <%= "hi"
+  %>
+<% end -%>

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.tsv.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.tsv.erb
@@ -1,7 +1,15 @@
-<%= "Title\tStatus\tAuthor(s)\tDOI\tLast modified\tLast modified by\tSize\tPublication date" %>
-<% @ds_identifiers.each do |i| %>
-  <% # nothing
-  -%>
-  <%= "hi"
-  %>
+<%= "Title\tStatus\tAuthor\tDOI\tLast modified\tLast modified by\tSize\tPublication date" %>
+<% @ds_identifiers.each do |i| -%>
+<%
+    latest_resource = i&.latest_resource
+    row = [ latest_resource&.title || '[no title set]',
+            i&.identifier_state&.current_curation_status,
+            latest_resource&.user&.name,
+            i.identifier,
+            formatted_datetime(i&.identifier_state&.curation_activity&.updated_at),
+            i&.identifier_state&.curation_activity&.user&.name,
+            i.storage_size,
+            "My last modified"
+    ]
+-%><%= row.join("\t") %>
 <% end -%>


### PR DESCRIPTION
If you go into the Admin area and click the link at the bottom that says "Get Tab Separated Values (TSV) for import into Excel" it will export this and you can open in Excel or similar program.  It exports without paging in one big TSV file.

I assume people will filter down, such as for items that are in a particular state that they need to look at and then export.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/151

This is deployed on dryad-dev.cdlib.org

