### PR TITLE
Making it not barf without curation statuses to display

### DIFF
--- a/stash_datacite/app/controllers/stash_datacite/resources_controller/dataset_presenter.rb
+++ b/stash_datacite/app/controllers/stash_datacite/resources_controller/dataset_presenter.rb
@@ -66,7 +66,7 @@ module StashDatacite
       end
 
       def embargo_status_pretty
-        embargo_status.tr('_', ' ')
+        embargo_status&.tr('_', ' ')
       end
 
       def publication_date


### PR DESCRIPTION
The display of bad dataset curation statuses results in blanks in the my datasets page now.