### PR TITLE
Making people put in their affiliation before they can start a dataset

### DIFF
--- a/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
@@ -56,7 +56,8 @@ module StashEngine
 
     # some people seem to get to the dashboard without having their tenant set.
     def ensure_tenant
-      redirect_to choose_sso_path, alert: "You must choose if you are associated with an institution before continuing" if current_user.tenant_id.blank?
+      return unless current_user.tenant_id.blank?
+      redirect_to choose_sso_path, alert: 'You must choose if you are associated with an institution before continuing'
     end
 
     def email_code

--- a/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/dashboard_controller.rb
@@ -3,6 +3,7 @@ require_dependency 'stash_engine/application_controller'
 module StashEngine
   class DashboardController < ApplicationController
     before_action :require_login, only: %i[show migrate_data_mail migrate_data]
+    before_action :ensure_tenant, only: :show
 
     MAX_VALIDATION_TRIES = 5
 
@@ -52,6 +53,11 @@ module StashEngine
 
     # methods below are private
     private
+
+    # some people seem to get to the dashboard without having their tenant set.
+    def ensure_tenant
+      redirect_to choose_sso_path, alert: "You must choose if you are associated with an institution before continuing" if current_user.tenant_id.blank?
+    end
 
     def email_code
       current_user.update(old_dryad_email: params[:email])

--- a/stash_engine/app/views/stash_engine/sessions/choose_login.html.erb
+++ b/stash_engine/app/views/stash_engine/sessions/choose_login.html.erb
@@ -3,7 +3,7 @@
     <h1>Login</h1>
 
     <%= link_to '/stash/auth/orcid?origin=login', class: 't-login__buttonlink' do %>
-      <%= image_tag('stash_engine/icon_orcid', class: 't-login__orcid-small', alt: 'ORCID logo') %>
+      <%= image_tag('stash_engine/icon_orcid.svg', class: 't-login__orcid-small', alt: 'ORCID logo') %>
       Login or create your ORCID iD
     <% end %>
 

--- a/stash_engine/app/views/stash_engine/sessions/choose_sso.html.erb
+++ b/stash_engine/app/views/stash_engine/sessions/choose_sso.html.erb
@@ -1,7 +1,7 @@
 <div class="t-login__section">
   <div class="t-login__choose">
     <h1>Login</h1>
-    <p><%= image_tag('stash_engine/icon_orcid', class: 't-login__orcid-small', alt: 'ORCID logo') %> <strong>ORCID login successful</strong></p>
+    <p><%= image_tag('stash_engine/icon_orcid.svg', class: 't-login__orcid-small', alt: 'ORCID logo') %> <strong>ORCID login successful</strong></p>
 
     <h2>Your institution may be a member* of Dryad.</h2>
     <div class="c-institution__container">


### PR DESCRIPTION
Also trying to fix the asset pipeline problem with orcid icon randomly not displaying on stage.  People online say that adding the file extension may fix this weird problem.

To test the affiliation not being set.

1.  Delete affiliation in DB.
2. Log in.
3. When asked for affiliation, click "My Datasets" and pretend you were never asked to do anything.
4. You should get redirected back to this page with a message telling you to fill in your f-ing affiliation.

I don't know if adding the svg to the image_tag filename will fix this problem.  It works fine on development and I don't think we'll know until we deploy to stage.  Some people online think it randomly fixes this weird problem.

