### PR TITLE
Filename sanitization

### DIFF
--- a/stash_api/Gemfile.lock
+++ b/stash_api/Gemfile.lock
@@ -59,6 +59,7 @@ PATH
       thor (= 0.19.1)
       wicked_pdf (~> 1.1.0)
       wkhtmltopdf-binary (~> 0.12.3.1)
+      zaru (~> 0.3)
 
 PATH
   remote: .
@@ -227,7 +228,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (4.4.3)
       railties (>= 4.2)
-    dotenv (2.7.0)
+    dotenv (2.7.1)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
     dry-container (0.6.0)
@@ -562,6 +563,7 @@ GEM
       mime-types (~> 3.0)
       typesafe_enum (~> 0.1, >= 0.1.8)
       xml-mapping (~> 0.10)
+    zaru (0.3.0)
 
 PLATFORMS
   ruby

--- a/stash_datacite/Gemfile.lock
+++ b/stash_datacite/Gemfile.lock
@@ -51,6 +51,7 @@ PATH
       thor (= 0.19.1)
       wicked_pdf (~> 1.1.0)
       wkhtmltopdf-binary (~> 0.12.3.1)
+      zaru (~> 0.3)
 
 PATH
   remote: .
@@ -221,7 +222,7 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.0)
+    dotenv (2.7.1)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
     dry-container (0.6.0)
@@ -577,6 +578,7 @@ GEM
       mime-types (~> 3.0)
       typesafe_enum (~> 0.1, >= 0.1.8)
       xml-mapping (~> 0.10)
+    zaru (0.3.0)
 
 PLATFORMS
   ruby

--- a/stash_engine/Gemfile
+++ b/stash_engine/Gemfile
@@ -7,7 +7,7 @@ gem 'mysql2', '< 0.5x', '>= 0.3.13'
 gem 'sortable-table', '~> 0.1'
 gem 'stash-sword', path: '../stash-sword'
 
-gem 'zaru', '~> 0.1'
+gem 'zaru', '~> 0.3' # Gem for sanitizing file names
 
 group :development, :test do
   gem 'factory_bot_rails', require: false

--- a/stash_engine/Gemfile
+++ b/stash_engine/Gemfile
@@ -7,6 +7,8 @@ gem 'mysql2', '< 0.5x', '>= 0.3.13'
 gem 'sortable-table', '~> 0.1'
 gem 'stash-sword', path: '../stash-sword'
 
+gem 'zaru', '~> 0.1'
+
 group :development, :test do
   gem 'factory_bot_rails', require: false
   # gem 'factory_bot'

--- a/stash_engine/Gemfile.lock
+++ b/stash_engine/Gemfile.lock
@@ -38,6 +38,7 @@ PATH
       thor (= 0.19.1)
       wicked_pdf (~> 1.1.0)
       wkhtmltopdf-binary (~> 0.12.3.1)
+      zaru (~> 0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -168,7 +169,7 @@ GEM
     docile (1.3.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.0)
+    dotenv (2.7.1)
     ebnf (1.1.3)
       rdf (~> 3.0)
       sxp (~> 1.0)
@@ -488,7 +489,7 @@ DEPENDENCIES
   stash-sword!
   stash_engine!
   webmock (~> 3.0)
-  zaru (~> 0.1)
+  zaru (~> 0.3)
 
 BUNDLED WITH
    1.17.3

--- a/stash_engine/Gemfile.lock
+++ b/stash_engine/Gemfile.lock
@@ -463,6 +463,7 @@ GEM
       mime-types (~> 3.0)
       typesafe_enum (~> 0.1, >= 0.1.8)
       xml-mapping (~> 0.10)
+    zaru (0.3.0)
 
 PLATFORMS
   ruby
@@ -487,6 +488,7 @@ DEPENDENCIES
   stash-sword!
   stash_engine!
   webmock (~> 3.0)
+  zaru (~> 0.1)
 
 BUNDLED WITH
    1.17.3

--- a/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash_engine/app/models/stash_engine/file_upload.rb
@@ -1,3 +1,5 @@
+require 'zaru'
+
 module StashEngine
   class FileUpload < ActiveRecord::Base
     belongs_to :resource, class_name: 'StashEngine::Resource'
@@ -86,6 +88,15 @@ module StashEngine
     def self.older_resource_named_dirs(uploads_dir)
       Dir.glob(File.join(uploads_dir, '*')).select { |i| %r{/\d+$}.match(i) }
         .select { |i| File.directory?(i) }.select { |i| File.mtime(i) + 7.days < Time.new }.map { |i| File.basename(i) }
+    end
+
+    def self.sanitize_file_name(name)
+      # remove invalid characters from the filename: https://github.com/madrobby/zaru
+      sanitized = Zaru.sanitize!(name)
+      # remove the delete control character
+      sanitized = sanitized.gsub(/\u007F/, '')
+      # remove some extra characters that Zaru does not remove by default
+      sanitized.gsub(/,|;|'|"/, '')
     end
   end
 end

--- a/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash_engine/app/models/stash_engine/file_upload.rb
@@ -93,12 +93,11 @@ module StashEngine
     def self.sanitize_file_name(name)
       # remove invalid characters from the filename: https://github.com/madrobby/zaru
       sanitized = Zaru.sanitize!(name)
+
       # remove the delete control character
-      # rubocop:disable Performance/StringReplacement
-      sanitized = sanitized.gsub(/\u007F/, '')
-      # rubocop:enable Performance/StringReplacement
       # remove some extra characters that Zaru does not remove by default
-      sanitized.gsub(/,|;|'|"/, '')
+      # replace spaces with underscores
+      sanitized.gsub(/,|;|'|"|\u007F/, '').strip.gsub(/\s+/, '_')
     end
   end
 end

--- a/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash_engine/app/models/stash_engine/file_upload.rb
@@ -94,7 +94,9 @@ module StashEngine
       # remove invalid characters from the filename: https://github.com/madrobby/zaru
       sanitized = Zaru.sanitize!(name)
       # remove the delete control character
+      # rubocop:disable Performance/StringReplacement
       sanitized = sanitized.gsub(/\u007F/, '')
+      # rubocop:enable Performance/StringReplacement
       # remove some extra characters that Zaru does not remove by default
       sanitized.gsub(/,|;|'|"/, '')
     end

--- a/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash_engine/app/models/stash_engine/url_validator.rb
@@ -79,8 +79,11 @@ module StashEngine
       # (duplicate indicated with 409 Conflict)
       return upload_attributes.merge(status_code: 409) if resource.url_in_version?(url)
 
+      sanitized_filename = StashEngine::FileUpload.sanitize_file_name(UrlValidator.make_unique(resource: resource, filename: filename))
+
       upload_attributes.merge(
-        upload_file_name: UrlValidator.make_unique(resource: resource, filename: filename),
+        upload_file_name: sanitized_filename,
+        original_filename: UrlValidator.make_unique(resource: resource, filename: filename),
         upload_content_type: mime_type,
         upload_file_size: size
       )

--- a/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash_engine/app/models/stash_engine/url_validator.rb
@@ -63,6 +63,7 @@ module StashEngine
 
     # need to give make_unique method may need moving
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def upload_attributes_from(translator:, resource:)
       valid = validate
       upload_attributes = {
@@ -88,6 +89,7 @@ module StashEngine
         upload_file_size: size
       )
     end
+    # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
     def timed_out?

--- a/stash_engine/db/migrate/20190228182559_add_original_file_name_to_stash_engine_file_uploads.rb
+++ b/stash_engine/db/migrate/20190228182559_add_original_file_name_to_stash_engine_file_uploads.rb
@@ -1,0 +1,5 @@
+class AddOriginalFileNameToStashEngineFileUploads < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_file_uploads, :original_filename, :text
+  end
+end

--- a/stash_engine/spec/db/stash_engine/file_upload_spec.rb
+++ b/stash_engine/spec/db/stash_engine/file_upload_spec.rb
@@ -90,8 +90,9 @@ module StashEngine
           expect(StashEngine::FileUpload.sanitize_file_name("#{i.chr}abc123")).to eql('abc123')
           expect(StashEngine::FileUpload.sanitize_file_name("abc123#{i.chr}")).to eql('abc123')
 
+          # Zaru replaces characters 9-13 with a space
           if (9..13).cover?(i)
-            expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc 123')
+            expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc_123')
           else
             expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc123')
           end
@@ -104,12 +105,30 @@ module StashEngine
         expect(StashEngine::FileUpload.sanitize_file_name("abc#{127.chr}123")).to eql('abc123')
       end
 
+      it 'replaces spaces with underscores' do
+        expect(StashEngine::FileUpload.sanitize_file_name("abc 123")).to eql('abc_123')
+        expect(StashEngine::FileUpload.sanitize_file_name("abc  123 ")).to eql('abc_123')
+      end
+
+      it 'removes trailing and leading spaces' do
+        expect(StashEngine::FileUpload.sanitize_file_name("  abc123")).to eql('abc123')
+        expect(StashEngine::FileUpload.sanitize_file_name("abc123  ")).to eql('abc123')
+      end
+
       %w[| / \\ : ; " ' < > , ?].each do |chr|
         it "removes #{chr}" do
           expect(StashEngine::FileUpload.sanitize_file_name("#{chr}abc123")).to eql('abc123')
           expect(StashEngine::FileUpload.sanitize_file_name("abc#{chr}123")).to eql('abc123')
           expect(StashEngine::FileUpload.sanitize_file_name("abc123#{chr}")).to eql('abc123')
         end
+      end
+
+      it 'does not remove foreign characters' do
+        expect(StashEngine::FileUpload.sanitize_file_name('abc𠝹Ѭμ123')).to eql('abc𠝹Ѭμ123')
+      end
+
+      it 'does not remove emoji characters' do
+        expect(StashEngine::FileUpload.sanitize_file_name('abc😂123')).to eql('abc😂123')
       end
 
     end

--- a/stash_engine/spec/db/stash_engine/file_upload_spec.rb
+++ b/stash_engine/spec/db/stash_engine/file_upload_spec.rb
@@ -82,5 +82,36 @@ module StashEngine
         expect(@upload.digest?).to be true
       end
     end
+
+    describe :sanitize_file_name do
+      # Ensure that non-printable ACII control characters < 32 are sanitized
+      it 'removes ASCII Control characters (0-31)' do
+        (0..31).each do |i|
+          expect(StashEngine::FileUpload.sanitize_file_name("#{i.chr}abc123")).to eql('abc123')
+          expect(StashEngine::FileUpload.sanitize_file_name("abc123#{i.chr}")).to eql('abc123')
+
+          if (9..13).include?(i)
+            expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc 123')
+          else
+            expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc123')
+          end
+        end
+      end
+
+      it 'removes ASCII Delete character (127)' do
+        expect(StashEngine::FileUpload.sanitize_file_name("#{127.chr}abc123")).to eql('abc123')
+        expect(StashEngine::FileUpload.sanitize_file_name("abc123#{127.chr}")).to eql('abc123')
+        expect(StashEngine::FileUpload.sanitize_file_name("abc#{127.chr}123")).to eql('abc123')
+      end
+
+      %w[| / \\ : ; " ' < > , ?].each do |chr|
+        it "removes #{chr}" do
+          expect(StashEngine::FileUpload.sanitize_file_name("#{chr}abc123")).to eql('abc123')
+          expect(StashEngine::FileUpload.sanitize_file_name("abc#{chr}123")).to eql('abc123')
+          expect(StashEngine::FileUpload.sanitize_file_name("abc123#{chr}")).to eql('abc123')
+        end
+      end
+
+    end
   end
 end

--- a/stash_engine/spec/db/stash_engine/file_upload_spec.rb
+++ b/stash_engine/spec/db/stash_engine/file_upload_spec.rb
@@ -90,7 +90,7 @@ module StashEngine
           expect(StashEngine::FileUpload.sanitize_file_name("#{i.chr}abc123")).to eql('abc123')
           expect(StashEngine::FileUpload.sanitize_file_name("abc123#{i.chr}")).to eql('abc123')
 
-          if (9..13).include?(i)
+          if (9..13).cover?(i)
             expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc 123')
           else
             expect(StashEngine::FileUpload.sanitize_file_name("abc#{i.chr}123")).to eql('abc123')

--- a/stash_engine/spec/db/stash_engine/file_upload_spec.rb
+++ b/stash_engine/spec/db/stash_engine/file_upload_spec.rb
@@ -106,13 +106,13 @@ module StashEngine
       end
 
       it 'replaces spaces with underscores' do
-        expect(StashEngine::FileUpload.sanitize_file_name("abc 123")).to eql('abc_123')
-        expect(StashEngine::FileUpload.sanitize_file_name("abc  123 ")).to eql('abc_123')
+        expect(StashEngine::FileUpload.sanitize_file_name('abc 123')).to eql('abc_123')
+        expect(StashEngine::FileUpload.sanitize_file_name('abc  123')).to eql('abc_123')
       end
 
       it 'removes trailing and leading spaces' do
-        expect(StashEngine::FileUpload.sanitize_file_name("  abc123")).to eql('abc123')
-        expect(StashEngine::FileUpload.sanitize_file_name("abc123  ")).to eql('abc123')
+        expect(StashEngine::FileUpload.sanitize_file_name('  abc123')).to eql('abc123')
+        expect(StashEngine::FileUpload.sanitize_file_name('abc123  ')).to eql('abc123')
       end
 
       %w[| / \\ : ; " ' < > , ?].each do |chr|

--- a/stash_engine/stash_engine.gemspec
+++ b/stash_engine/stash_engine.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_dependency 'sortable-table'
   s.add_dependency 'wicked_pdf', '~> 1.1.0'
   s.add_dependency 'wkhtmltopdf-binary', '~> 0.12.3.1'
+  s.add_dependency 'zaru', '~> 0.3'
 
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'chromedriver-helper'


### PR DESCRIPTION
- Added the Zaru gem to the Gemfile
- Added a `sanitize_file_name(name)` class method to the FileUpload model
- Updated FileUpload controller to sanitize incoming file uploads and Url based files
- Added `stash_engine_file_uploads.original_filename` so that we have the original unsanitized name should we want to somehow notify the user in the UI that the name changed.