### PR TITLE
Updated `submit_to_stripe` callback so that it happens on published/embargoed

### DIFF
--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -51,8 +51,7 @@ module StashEngine
     # Callbacks
     # ------------------------------------------
     # When the status is published send to Stripe and DataCite
-    after_save :submit_to_stripe, if: :ready_for_payment?
-    after_create :submit_to_datacite, :update_solr, if: :published? || :embargoed?
+    after_create :submit_to_datacite, :update_solr, submit_to_stripe, if: :published? || :embargoed?
 
     after_create :update_resource_reference!
     after_destroy :remove_resource_reference!

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -51,7 +51,8 @@ module StashEngine
     # Callbacks
     # ------------------------------------------
     # When the status is published send to Stripe and DataCite
-    after_create :submit_to_datacite, :update_solr, submit_to_stripe, if: :published? || :embargoed?
+    after_create :submit_to_datacite, :update_solr, :submit_to_stripe,
+                 if: proc { |ca| ca.published? || ca.embargoed? }
 
     after_create :update_resource_reference!
     after_destroy :remove_resource_reference!

--- a/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_popup.js.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_popup.js.erb
@@ -24,7 +24,6 @@ $(function() {
 
   // Publication Date should only show when the user sets the status to Complete
   function togglePublicationDate(selector) {
-console.log($('#resource_publication_date').val());
     if ($(selector).find('option:selected').val() === 'published' ||
         $(selector).find('option:selected').val() === 'embargoed' ||
         $('#resource_publication_date').val()) {

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -100,6 +100,13 @@ module StashEngine
           ca.save
         end
 
+        it 'calls update_solr when embargoed' do
+          @resource.update(publication_date: (Date.today + 1.day).to_s)
+          ca = CurationActivity.new(resource_id: @resource.id, status: 'embargoed')
+          expect(ca).to receive(:update_solr)
+          ca.save
+        end
+
         it 'does not call update_solr if not published' do
           @resource.update(publication_date: Date.today.to_s)
           ca = CurationActivity.new(resource_id: @resource.id, status: 'action_required')
@@ -118,6 +125,12 @@ module StashEngine
           ca.save
         end
 
+        it 'calls submit_to_datacite when embargoed' do
+          ca = CurationActivity.new(resource_id: @resource.id, status: 'embargoed')
+          expect(ca).to receive(:submit_to_datacite)
+          ca.save
+        end
+
         it 'does not call submit_to_datacite if not published' do
           @resource.update(publication_date: Date.today.to_s)
           ca = CurationActivity.new(resource_id: @resource.id, status: 'action_required')
@@ -129,14 +142,21 @@ module StashEngine
 
       context :submit_to_stripe do
 
-        it 'calls submit_to_datacite when ready_for_payment' do
+        it 'calls submit_to_stripe when published' do
           allow_any_instance_of(StashEngine::CurationActivity).to receive(:ready_for_payment?).and_return(true)
-          ca = CurationActivity.new(resource_id: @resource.id, status: 'submitted')
+          ca = CurationActivity.new(resource_id: @resource.id, status: 'published')
           expect(ca).to receive(:submit_to_stripe)
           ca.save
         end
 
-        it 'does not call submit_to_datacite if not ready_for_payment' do
+        it 'calls submit_to_stripe when embargoed' do
+          allow_any_instance_of(StashEngine::CurationActivity).to receive(:ready_for_payment?).and_return(true)
+          ca = CurationActivity.new(resource_id: @resource.id, status: 'embargoed')
+          expect(ca).to receive(:submit_to_stripe)
+          ca.save
+        end
+
+        it 'does not call submit_to_stripe if not ready_for_payment' do
           allow_any_instance_of(StashEngine::CurationActivity).to receive(:ready_for_payment?).and_return(false)
           ca = CurationActivity.new(resource_id: @resource.id, status: 'submitted')
           expect(ca).not_to receive(:submit_to_stripe)


### PR DESCRIPTION
Some additional tweaks to the embargo cleanup

- fixed typo in definition of callback conditional
- @ryscher confirmed that `submit_to_stripe` should only be called if the dataset is published or embargoed (logic is still in place to make sure we have not already invoiced for the dataset)
- updated all callback tests to check 'embargoed' state
- removed `console.log` statement from JS