### PR TITLE
Minor changes discovered when building out new test framework on Dryad repo

### DIFF
--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -63,6 +63,10 @@ module StashEngine
       init_state
       init_version
       save
+      # Need to reload self here because some of the associated dependencies
+      # update back on this object when they save (e.g. current_curation_activity,
+      # current_resource_state, etc.)
+      reload
     end
 
     def update_stash_identifier_last_resource
@@ -292,7 +296,7 @@ module StashEngine
 
     # Create the initial CurationActivity
     def init_curation_status
-      curation_activities << StashEngine::CurationActivity.new
+      curation_activities << StashEngine::CurationActivity.new(user: user)
     end
     private :init_curation_status
 

--- a/stash_engine/app/views/layouts/stash_engine/application.html.erb
+++ b/stash_engine/app/views/layouts/stash_engine/application.html.erb
@@ -40,7 +40,7 @@
       <%= link_to(stash_url_helpers.root_path, class: 'c-header__dash-logo-link js-nav-out') do %>
         <%
           dash_logo = image_tag('stash_engine/logo_dryad.png', class: 'c-header__dash-logo-svg', alt: 'Dryad logo')
-        tenant_logo = ( current_tenant.logo_file.blank? ? '' : logo_path(class: "c-header__dash-logo-svg") ) %>
+        tenant_logo = ( (current_tenant.blank? || current_tenant.logo_file.blank?) ? '' : logo_path(class: "c-header__dash-logo-svg") ) %>
         <%= dash_logo %><%= tenant_logo %>
       <% end %>
     </div>


### PR DESCRIPTION
- reloads self after Resource model initializes dependencies (to ensure refs to latest/current are up to date)
- make sure initial curation_activity uses the user_id on the resource
- add check for missing current_tenant on application.html.erb