### PR TITLE
Form for automatic publication fill-in with no errors when submitting

### DIFF
--- a/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
+++ b/stash_datacite/app/assets/javascripts/stash_datacite/publications.js
@@ -80,4 +80,10 @@ function loadPublications() {
             $(form).trigger('submit.rails');
         }
     });
+    // trap the submit button, change hidden 'do_import' = 'true' and then submit when this button is clicked
+    $('.js-import-ms').click(function(e){
+        e.preventDefault();
+        $('#internal_datum_do_import').val('true');
+        $(this).closest("form").submit();
+    });
 };

--- a/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -8,11 +8,9 @@ module StashDatacite
       @metadata_entry = Resource::MetadataEntry.new(@resource, current_tenant)
       @metadata_entry.resource_type
       se_id = StashEngine::Identifier.find(@resource.identifier_id)
-      @publication = StashEngine::InternalDatum.find_by(stash_identifier: se_id, data_type: 'publicationISSN')
-      @publication = StashEngine::InternalDatum.new(stash_identifier: se_id, data_type: 'publicationISSN') if @publication.nil?
+      @publication = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'publicationISSN')
+      @msid = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
 
-      @msid = StashEngine::InternalDatum.find_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
-      @msid = StashEngine::InternalDatum.new(stash_identifier: se_id, data_type: 'manuscriptNumber') if @msid.nil?
       respond_to do |format|
         format.js
       end

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -1,42 +1,45 @@
 require_dependency 'stash_datacite/application_controller'
 require 'httparty'
+require 'byebug'
 
 module StashDatacite
   class PublicationsController < ApplicationController
-    include HTTParty
+    # include HTTParty
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def update
       @se_id = StashEngine::Identifier.find(params[:internal_datum][:identifier_id])
-      @pub_issn = StashEngine::InternalDatum.find_by(stash_identifier: @se_id, data_type: 'publicationISSN')
-      @pub_issn = StashEngine::InternalDatum.new(stash_identifier: @se_id, data_type: 'publicationISSN') if @pub_issn.nil?
-
-      @msid = StashEngine::InternalDatum.find_by(stash_identifier: @se_id, data_type: 'manuscriptNumber')
-      @msid = StashEngine::InternalDatum.new(stash_identifier: @se_id, data_type: 'manuscriptNumber') if @msid.nil?
+      @pub_issn = StashEngine::InternalDatum.find_or_create_by(stash_identifier: @se_id, data_type: 'publicationISSN')
+      @msid = StashEngine::InternalDatum.find_or_create_by(stash_identifier: @se_id, data_type: 'manuscriptNumber')
+      issn =  params[:internal_datum][:publication_issn]
+      msid = params[:internal_datum][:msid]
+      @pub_issn.update(value: issn) unless issn.blank?
+      @msid.update(value: msid) unless msid.blank?
       respond_to do |format|
-        format.js { render template: 'stash_datacite/shared/update.js.erb' } if @pub_issn.update(value: params[:internal_datum][:publication_issn])
-        format.js { render template: 'stash_datacite/shared/update.js.erb' } if @msid.update(value: params[:internal_datum][:msid])
+        format.js do
+          if params[:internal_datum][:do_import] == 'true'
+            # take action to do the actual import and reload the page with javascript
+            update_metadata
+            render 'update' # just the standard update in the associated view directory
+          else
+            render template: 'stash_datacite/shared/update.js.erb'
+          end
+        end
       end
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-    # rubocop:disable Metrics/MethodLength
-    def autofill_data
-      @id = params[:id]
-      @se_id = StashEngine::Identifier.find(StashEngine::Resource.find(params[:id]).identifier_id)
-      @pub_issn = StashEngine::InternalDatum.find_by(identifier_id: @se_id, data_type: 'publicationISSN').value
-      @msid = StashEngine::InternalDatum.find_by(identifier_id: @se_id, data_type: 'manuscriptNumber').value
+    def update_metadata
+      pub_issn_only = @pub_issn.value
+      msid_only = @msid.value
       body = { dryadDOI: 'doi:' + @se_id.identifier,
                dashUserID: current_user.id,
-               manuscriptNumber: @msid }.to_json
-      url = APP_CONFIG.old_dryad_url + '/api/v1/journals/' + @pub_issn + '/packages/'
+               manuscriptNumber: msid_only }.to_json
+      url = "#{APP_CONFIG.old_dryad_url}/api/v1/journals/#{pub_issn_only}/packages/"
       @results = HTTParty.put(url,
                               query: { access_token: APP_CONFIG.old_dryad_access_token },
                               body: body,
                               headers: { 'Content-Type' => 'application/json' })
-      redirect_to :back
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
-
   end
 end

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -1,14 +1,20 @@
-<%= form_for(@publication, url: publications_update_path, method: :patch, remote: true, authenticity_token: true, html: { class: 'c-input__inline' }) do |f| %>
-	<div class="c-input">
-		<%= f.label "journal_name", 'Journal Name', class: 'c-input__label' %>
-		<%= f.text_field :publication_name, value: @publication.value, class: "js-publications c-input__text" %>
-    <%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
-    <%= f.hidden_field :resource_id, value: @resource.id %>
-    <%= f.hidden_field :publication_issn, value: @publication.value %>
-  </div>
-  <div class="c-input">
-    <%= f.label "msid", 'Manuscript Number', class: 'c-input__label' %>
-    <%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text" %>
-  </div>
+<%= form_for(@publication, url: publications_update_path, method: :patch, remote: true, authenticity_token: true) do |f| %>
+	<div class="c-input__inline">
+		<div class="c-input">
+			<%= f.label "journal_name", 'Journal Name', class: 'c-input__label' %>
+			<%= f.text_field :publication_name, value: @publication.value, class: "js-publications c-input__text" %>
+			<%= f.hidden_field :identifier_id, value: @resource.identifier_id %>
+			<%= f.hidden_field :resource_id, value: @resource.id %>
+			<%= f.hidden_field :publication_issn, value: @publication.value %>
+			<%= f.hidden_field :do_import, value: 'false' %>
+		</div>
+		<div class="c-input">
+			<%= f.label "msid", 'Manuscript Number', class: 'c-input__label' %>
+			<%= f.text_field :msid, value: @msid.value, class: "js-msid c-input__text" %>
+		</div>
+	</div>
+	<div>
+		<%= f.submit "Import Manuscript Metadata", method: :post, class: 'js-import-ms o-button__import-manuscript' %>
+	</div>
 <% end %>
-<%= link_to "Import Manuscript Metadata", publications_autofill_data_path( id: @resource.id ), method: :post, class: 'o-button__jane-random' %>
+<div id="population-warnings" class="o-metadata__autopopulate-message"></div>

--- a/stash_datacite/app/views/stash_datacite/publications/update.js.erb
+++ b/stash_datacite/app/views/stash_datacite/publications/update.js.erb
@@ -1,0 +1,12 @@
+// switch do_import hidden value back to false in case form needs to be played with some more
+$('#internal_datum_do_import').val('false');
+
+<% if @results.code > 199 && @results.code < 300 %>
+  // get data into DB somehow and reload the page to show the pretty new data, which also resets this form to defaults
+  location.reload(true);
+<% else %>
+  // populate and display warning
+  $( '#population-warnings' ).text("Could not retrieve manuscript data.  Please re-check the journal and manuscript number.");
+  $( "#population-warnings" ).show();
+  $('#internal_datum_do_import').val('false');  // reset the import to false again, to be changed back by js with submit button click event
+<% end %>

--- a/stash_datacite/app/views/stash_datacite/shared/update.js.erb
+++ b/stash_datacite/app/views/stash_datacite/shared/update.js.erb
@@ -1,1 +1,2 @@
 $( "div.success" ).show().delay( 1000 ).fadeOut( 400 );
+$( "#population-warnings" ).hide();

--- a/stash_engine/app/assets/stylesheets/stash_engine/ui.css
+++ b/stash_engine/app/assets/stylesheets/stash_engine/ui.css
@@ -3003,11 +3003,11 @@ html.no-multiplebgs .o-banner {
   border: none;
   background: transparent url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%22512%22%20height%3D%22512%22%3E%3Cpath%20d%3D%22M16.043%2011.667L22.609%205.1a2.484%202.484%200%200%200%200-3.502l-.875-.875a2.482%202.482%200%200%200-3.502%200L11.666%207.29%205.099.723a2.482%202.482%200%200%200-3.501%200l-.876.875a2.485%202.485%200%200%200%200%203.502l6.566%206.566-6.566%206.567a2.484%202.484%200%200%200%200%203.501l.876.875a2.482%202.482%200%200%200%203.501%200l6.567-6.565%206.566%206.565a2.484%202.484%200%200%200%203.502%200l.875-.875a2.482%202.482%200%200%200%200-3.501l-6.566-6.566z%22%20fill%3D%22%23FFF%22%2F%3E%3C%2Fsvg%3E') center/15px no-repeat; }
 
-.o-button__add, .o-button__jane-random, .o-button__remove {
+.o-button__add, .o-button__import-manuscript, .o-button__remove {
   display: inline-block;
   text-align: left;
   text-decoration: none; }
-  .o-button__add::before, .o-button__jane-random::before, .o-button__remove::before {
+  .o-button__add::before, .o-button__import-manuscript::before, .o-button__remove::before {
     margin: 0 0.25em 0 0; }
 
 .o-button__add {
@@ -3018,9 +3018,11 @@ html.no-multiplebgs .o-banner {
   .o-button__add::before {
     content: '+'; }
 
-.o-button__jane-random {
+.o-button__import-manuscript {
+  display: block;
   margin: 0 0 20px;
   padding: 5px 8px;
+  clear: both;
   border: 1px solid #9fc7d8;
   background-color: #9fc7d8;
   color: black; }
@@ -3341,6 +3343,11 @@ button.o-button__calendar:focus {
 
 .o-metadata__group2-item {
   margin-bottom: 0.5em; }
+
+.o-metadata__autopopulate-message {
+  display: block;
+  margin: 0 0 0.5rem;
+  color: #e65722; }
 
 .o-metrics {
   /* display: flex;

--- a/stash_engine/public/demo/css/ui.css
+++ b/stash_engine/public/demo/css/ui.css
@@ -3003,11 +3003,11 @@ html.no-multiplebgs .o-banner {
   border: none;
   background: transparent url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20width%3D%22512%22%20height%3D%22512%22%3E%3Cpath%20d%3D%22M16.043%2011.667L22.609%205.1a2.484%202.484%200%200%200%200-3.502l-.875-.875a2.482%202.482%200%200%200-3.502%200L11.666%207.29%205.099.723a2.482%202.482%200%200%200-3.501%200l-.876.875a2.485%202.485%200%200%200%200%203.502l6.566%206.566-6.566%206.567a2.484%202.484%200%200%200%200%203.501l.876.875a2.482%202.482%200%200%200%203.501%200l6.567-6.565%206.566%206.565a2.484%202.484%200%200%200%203.502%200l.875-.875a2.482%202.482%200%200%200%200-3.501l-6.566-6.566z%22%20fill%3D%22%23FFF%22%2F%3E%3C%2Fsvg%3E') center/15px no-repeat; }
 
-.o-button__add, .o-button__jane-random, .o-button__remove {
+.o-button__add, .o-button__import-manuscript, .o-button__remove {
   display: inline-block;
   text-align: left;
   text-decoration: none; }
-  .o-button__add::before, .o-button__jane-random::before, .o-button__remove::before {
+  .o-button__add::before, .o-button__import-manuscript::before, .o-button__remove::before {
     margin: 0 0.25em 0 0; }
 
 .o-button__add {
@@ -3018,9 +3018,11 @@ html.no-multiplebgs .o-banner {
   .o-button__add::before {
     content: '+'; }
 
-.o-button__jane-random {
+.o-button__import-manuscript {
+  display: block;
   margin: 0 0 20px;
   padding: 5px 8px;
+  clear: both;
   border: 1px solid #9fc7d8;
   background-color: #9fc7d8;
   color: black; }
@@ -3341,6 +3343,11 @@ button.o-button__calendar:focus {
 
 .o-metadata__group2-item {
   margin-bottom: 0.5em; }
+
+.o-metadata__autopopulate-message {
+  display: block;
+  margin: 0 0 0.5rem;
+  color: #e65722; }
 
 .o-metrics {
   /* display: flex;

--- a/stash_engine/ui-library/scss/_buttons.scss
+++ b/stash_engine/ui-library/scss/_buttons.scss
@@ -237,10 +237,12 @@
 
 }
 
-.o-button__jane-random {
+.o-button__import-manuscript {
   @extend %o-button__add-remove;
+  display: block;
   margin: 0 0 20px;
   padding: 5px 8px;
+  clear: both;
   border: 1px solid $design-lighter-blue-color;
   background-color: $design-lighter-blue-color;
   color: $design-black-color;

--- a/stash_engine/ui-library/scss/_metadata.scss
+++ b/stash_engine/ui-library/scss/_metadata.scss
@@ -29,3 +29,9 @@
 .o-metadata__group2-item {
   margin-bottom: 0.5em;
 }
+
+.o-metadata__autopopulate-message {
+	display: block;
+	margin: 0 0 0.5rem;
+	color: $design-orange-color;
+}


### PR DESCRIPTION
This is a commit across all 3 repos.

See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/161 .

Making the form for this robust so that it doesn't error when people put publications in and it try to autopopulate their metadata.

Doesn't barf and gives a message if it can't get their metadata (which is always right now until other other end of this api is redesigned).