### PR TITLE
Preserve curation status

### DIFF
--- a/stash_api/.rubocop.yml
+++ b/stash_api/.rubocop.yml
@@ -11,3 +11,7 @@ AllCops:
     - 'vendor/**/*'
     - 'ui-library/**/*'
     - 'node_modules/**/*'
+
+# The default MethodLength can flag methods which essentially do nothing, simply because they invoke another method with several parameters
+Metrics/MethodLength:
+  Max: 20

--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -69,15 +69,12 @@ module StashApi
     # Publish, embargo or simply change the status
     def create_curation_activity(resource)
       return unless resource.present?
-      logger.debug("Adding curation activity with status #{params[:curation_activity][:status]}")
 
       case params[:curation_activity][:status]
       when 'published'
-        publish_date = params[:curation_activity][:created_at] || date
-        resource.update!(publication_date: publish_date)
+        record_published_date(resource)
       when 'embargoed'
-        embargo_date = (params[:curation_activity][:created_at]&.to_date || Date.today) + 1.year
-        resource.update!(publication_date: embargo_date)
+        record_embargoed_date(resource)
       end
 
       user = params[:user_id] || @user.id
@@ -85,6 +82,16 @@ module StashApi
                                            user_id: user,
                                            status: params[:curation_activity][:status],
                                            note: params[:curation_activity][:note])
+    end
+
+    def record_published_date(resource)
+      publish_date = params[:curation_activity][:created_at] || date
+      resource.update!(publication_date: publish_date)
+    end
+
+    def record_embargoed_date(resource)
+      embargo_date = (params[:curation_activity][:created_at]&.to_date || Date.today) + 1.year
+      resource.update!(publication_date: embargo_date)
     end
 
   end

--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -68,7 +68,6 @@ module StashApi
 
     # Publish, embargo or simply change the status
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def create_curation_activity(resource)
       user = params[:user_id] || @user.id
       return unless resource.present?
@@ -85,7 +84,7 @@ module StashApi
                                              note: params[:curation_activity][:note])
       end
     end
-    # rubocop:enable Metrics/MethodLength
+
     # rubocop:enable Metrics/AbcSize
 
   end

--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -67,25 +67,25 @@ module StashApi
     private
 
     # Publish, embargo or simply change the status
-    # rubocop:disable Metrics/AbcSize
     def create_curation_activity(resource)
-      user = params[:user_id] || @user.id
       return unless resource.present?
       logger.debug("Adding curation activity with status #{params[:curation_activity][:status]}")
+
       case params[:curation_activity][:status]
       when 'published'
-        resource.publish!(user, Date.today, params[:curation_activity][:note])
+        publish_date = params[:curation_activity][:created_at] || date
+        resource.update!(publication_date: publish_date)
       when 'embargoed'
-        resource.embargo!(user, Date.today + 1.year, params[:curation_activity][:note])
-      else
-        StashEngine::CurationActivity.create(resource_id: resource.id,
-                                             user_id: user,
-                                             status: params[:curation_activity][:status],
-                                             note: params[:curation_activity][:note])
+        embargo_date = (params[:curation_activity][:created_at]&.to_date || Date.today) + 1.year
+        resource.update!(publication_date: embargo_date)
       end
-    end
 
-    # rubocop:enable Metrics/AbcSize
+      user = params[:user_id] || @user.id
+      StashEngine::CurationActivity.create(resource_id: resource.id,
+                                           user_id: user,
+                                           status: params[:curation_activity][:status],
+                                           note: params[:curation_activity][:note])
+    end
 
   end
 end

--- a/stash_api/app/controllers/stash_api/datasets/submission_mixin.rb
+++ b/stash_api/app/controllers/stash_api/datasets/submission_mixin.rb
@@ -41,8 +41,6 @@ module SubmissionMixin
   end
 
   def pre_submission_updates
-    @resource.update_publication_date!
-    @resource.save
     StashDatacite::DataciteDate.set_date_available(resource_id: @resource.id)
     StashEngine::EditHistory.create(resource_id: @resource.id, user_comment: 'submitted from API')
   end

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -41,7 +41,6 @@ module StashApi
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     # get /datasets
     def index
       # if a publicationISSN is specified, we want to make sure that we're only working with those:
@@ -67,7 +66,6 @@ module StashApi
         format.json { render json: @datasets }
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # we are using PATCH only to update the versionStatus=submitted
     # PUT will be to update/replace the dataset metadata
@@ -75,7 +73,6 @@ module StashApi
     # we are also allowing UPSERT with a PUT as in the pattern at
     # https://www.safaribooksonline.com/library/view/restful-web-services/9780596809140/ch01s09.html or
     # https://stackoverflow.com/questions/18470588/in-rest-is-post-or-put-best-suited-for-upsert-operation
-    # rubocop:disable Metrics/MethodLength
     def update
       do_patch { return } # check if patch and do submission and return early if it is a patch (submission)
       # otherwise this is a PUT of the dataset metadata
@@ -93,7 +90,6 @@ module StashApi
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     # get /datasets/<id>/download
     def download
@@ -183,9 +179,8 @@ module StashApi
       return if check_may_set_user_id == false
     end
 
-    # rubocop:disable Metrics/MethodLength
     def check_superuser_restricted_params
-      %w[skipDataciteUpdate skipEmails loosenValidation].each do |attr|
+      %w[skipDataciteUpdate skipEmails preserveCurationStatus loosenValidation].each do |attr|
         item_value = params[attr]
         unless item_value.nil? || item_value.class == TrueClass || item_value.class == FalseClass
           render json: { error: "Bad Request: #{attr} must be true or false" }.to_json, status: 400
@@ -197,7 +192,6 @@ module StashApi
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
 
     def check_may_set_user_id
       return if params['userId'].nil?

--- a/stash_api/app/controllers/stash_api/files_controller.rb
+++ b/stash_api/app/controllers/stash_api/files_controller.rb
@@ -114,7 +114,6 @@ module StashApi
               status: 403) && yield
     end
 
-    # rubocop:disable Metrics/MethodLength
     def save_file_to_db
       md5 = Digest::MD5.file(@file_path).hexdigest
       just_user_fn = @file_path[@resource.upload_dir.length..-1].gsub(%r{^/+}, '') # just user fn and remove any leading slashes
@@ -133,7 +132,6 @@ module StashApi
         original_filename: @original_filename || just_user_fn
       )
     end
-    # rubocop:enable Metrics/MethodLength
 
     def handle_previous_duplicates(upload_filename:)
       StashEngine::FileUpload.where(resource_id: @resource.id, upload_file_name: upload_filename).each do |file_upload|

--- a/stash_api/app/controllers/stash_api/urls_controller.rb
+++ b/stash_api/app/controllers/stash_api/urls_controller.rb
@@ -13,7 +13,7 @@ module StashApi
     before_action :require_permission, only: :create
     before_action :require_correctly_formatted_url, only: :create
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize
     def create
       file_upload_hash = if params['skipValidation'] == true
                            skipped_validation_hash(params) { return } # return will be yielded to if error is rendered, so it returns here
@@ -34,11 +34,11 @@ module StashApi
         format.json { render json: file.metadata, status: 201 }
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize
 
     private
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def validate_url(url)
       url_translator = Stash::UrlTranslator.new(url)
       validator = StashEngine::UrlValidator.new(url: url_translator.direct_download || url)
@@ -52,7 +52,7 @@ module StashApi
       end
       validation_hash
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def skipped_validation_hash(_hsh)

--- a/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash_api/app/models/stash_api/dataset_parser.rb
@@ -18,7 +18,6 @@ module StashApi
     end
 
     # this is the basic required metadata
-    # rubocop:disable Metrics/MethodLength
     def parse
       if @resource.nil?
         create_dataset(doi_string: @id_string) # @id string will be nil if not specified, so minted, otherwise to be created
@@ -32,6 +31,7 @@ module StashApi
         current_editor_id: user_id,
         skip_datacite_update: @hash['skipDataciteUpdate'] || false,
         skip_emails: @hash['skipEmails'] || false,
+        preserve_curation_status: @hash['preserveCurationStatus'] || false,
         loosen_validation: @hash['loosenValidation'] || false
       )
       # probably want to clear and re-add authors for data updates
@@ -40,7 +40,6 @@ module StashApi
       TO_PARSE.each { |item| dynamic_parse(my_class: item) }
       @resource.identifier
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 

--- a/stash_api/app/models/stash_api/dataset_parser/related_works.rb
+++ b/stash_api/app/models/stash_api/dataset_parser/related_works.rb
@@ -18,7 +18,7 @@ module StashApi
       LowerRelationTypes = StashDatacite::RelatedIdentifier::RelationTypes.map(&:downcase)
       LowerIdentifierTypes = StashDatacite::RelatedIdentifier::RelatedIdentifierTypes.map(&:downcase)
 
-      def parse # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def parse # rubocop:disable Metrics/AbcSize
         clear
         return if @hash['relatedWorks'].blank?
         @hash['relatedWorks'].each do |rw|

--- a/stash_api/app/models/stash_api/user.rb
+++ b/stash_api/app/models/stash_api/user.rb
@@ -8,7 +8,6 @@ module StashApi
       @se_user = StashEngine::User.find(user_id)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def metadata
       { '_links': links }.merge(
         id: @se_user.id,
@@ -23,7 +22,6 @@ module StashApi
         createdAt: @se_user.created_at
       )
     end
-    # rubocop:enable Metrics/MethodLength
 
     def links
       basic_links.compact.merge(stash_curie)

--- a/stash_api/app/models/stash_api/version/metadata.rb
+++ b/stash_api/app/models/stash_api/version/metadata.rb
@@ -8,7 +8,7 @@ module StashApi
         @resource = resource
       end
 
-      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:disable Metrics/AbcSize
       def value
         # setting some false values to nil because they get compacted.  Don't really want to advertise these options for
         # use by others besides ourselves because we don't want others to use them.
@@ -28,10 +28,11 @@ module StashApi
           userId: @resource.user_id,
           skipDataciteUpdate: @resource.skip_datacite_update || nil,
           skipEmails: @resource.skip_emails || nil,
+          preserveCurationStatus: @resource.preserve_curation_status || nil,
           loosenValidation: @resource.loosen_validation || nil
         }
       end
-      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/stash_api/lib/core_extensions/hash/recursive_compact.rb
+++ b/stash_api/lib/core_extensions/hash/recursive_compact.rb
@@ -14,7 +14,7 @@ module CoreExtensions
 
       # something weird happens in here because objects don't match the Hash class and not even is_a? hash.
       # I have to create a new hash/array and see if the classes match to get this to work.  Yuck.
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def helper_hash_compact(hsh)
         hsh.each_with_object({}) do |(k, v), new_hash|
           next if v.nil? || ((v.class == {}.class || v.class == [].class) && v.empty?)
@@ -30,7 +30,7 @@ module CoreExtensions
 
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       def helper_array_compact(arr)
         new_arr = arr.map do |i|

--- a/stash_api/spec/unit/models/stash_api/dataset_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_spec.rb
@@ -72,6 +72,10 @@ module StashApi
         expect(@metadata[:skipEmails]).to eq(nil)
       end
 
+      it 'hides preserveCurationStatus if false' do
+        expect(@metadata[:preserveCurationStatus]).to eq(nil)
+      end
+
       it 'hides loosenValidation if false' do
         expect(@metadata[:loosenValidation]).to eq(nil)
       end
@@ -88,6 +92,13 @@ module StashApi
         @dataset = Dataset.new(identifier: @identifier.to_s)
         @metadata = @dataset.metadata
         expect(@metadata[:skipEmails]).to eq(true)
+      end
+
+      it 'shows preserveCurationStatus when true' do
+        @identifier.in_progress_resource.update(preserve_curation_status: true)
+        @dataset = Dataset.new(identifier: @identifier.to_s)
+        @metadata = @dataset.metadata
+        expect(@metadata[:preserveCurationStatus]).to eq(true)
       end
 
       it 'shows loosenValidation when true' do

--- a/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -79,7 +79,10 @@ module StashDatacite
     private
 
     def update_submission_resource_info(resource)
-      resource.update(skip_datacite_update: false, skip_emails: false, loosen_validation: false) # these are mostly for API superusers to choose
+      resource.update(skip_datacite_update: false,
+                      skip_emails: false,
+                      preserve_curation_status: false,
+                      loosen_validation: false) # these are mostly for API superusers to choose
 
       # TODO: put this somewhere more reliable
       StashDatacite::DataciteDate.set_date_available(resource_id: resource.id)

--- a/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/resources_controller.rb
@@ -1,7 +1,5 @@
 require_dependency 'stash_datacite/application_controller'
 
-# require 'stash_datacite/merritt_packager'
-
 module StashDatacite
   # this is a class for composite (AJAX/UJS?) views starting at the resource or resources
   class ResourcesController < ApplicationController
@@ -20,8 +18,7 @@ module StashDatacite
           # only a page of objects needs calculations for display rather than all objects in list.  However if we need
           # to sort on calculated fields for display we'll need to calculate all values, sort and use the array pager
           # form of kaminari instead (which will likely be slower).
-          @resources = StashEngine::Resource.where(user_id: session[:user_id]).in_progress
-            .order(updated_at: :desc).page(@page).per(@page_size)
+          @resources = StashEngine::Resource.where(user_id: session[:user_id]).in_progress.order(updated_at: :desc).page(@page).per(@page_size)
           @in_progress_lines = @resources.map { |resource| DatasetPresenter.new(resource) }
         end
       end
@@ -30,9 +27,7 @@ module StashDatacite
     def user_submitted
       respond_to do |format|
         format.js do
-          # @resources = StashEngine::Resource.where(user_id: session[:user_id]).submitted.
-          @resources = current_user.latest_completed_resource_per_identifier.order(updated_at: :desc)
-            .page(@page).per(@page_size)
+          @resources = current_user.latest_completed_resource_per_identifier.order(updated_at: :desc).page(@page).per(@page_size)
           @submitted_lines = @resources.map { |resource| DatasetPresenter.new(resource) }
         end
       end
@@ -79,10 +74,8 @@ module StashDatacite
     private
 
     def update_submission_resource_info(resource)
-      resource.update(skip_datacite_update: false,
-                      skip_emails: false,
-                      preserve_curation_status: false,
-                      loosen_validation: false) # these are mostly for API superusers to choose
+      resource.update(skip_datacite_update: false, skip_emails: false,
+                      preserve_curation_status: false, loosen_validation: false) # these are mostly for API superusers to choose
 
       # TODO: put this somewhere more reliable
       StashDatacite::DataciteDate.set_date_available(resource_id: resource.id)

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -276,7 +276,9 @@ module StashEngine
       raise "current_resource_state not initialized for resource #{id}" unless my_state
       my_state.resource_state = value
       # If the resource_state is in_progress or submitted then create a corresponding curation_activity
-      if %w[in_progress submitted].include?(value)
+      # But don't create the curation_activity if preserve_curation_status is set, because a user who has
+      # set that flag is expecting the curation_status to remain as whatever they have already set.
+      if %w[in_progress submitted].include?(value) && !preserve_curation_status
         status = identifier&.internal_data&.present? ? 'peer_review' : value
         StashEngine::CurationActivity.create(resource: self, user: user, status: status)
       end

--- a/stash_engine/app/models/stash_engine/resource_state.rb
+++ b/stash_engine/app/models/stash_engine/resource_state.rb
@@ -13,7 +13,10 @@ module StashEngine
 
     # Add a record to the CurationActivities for the Resource IF the new resource_state
     # is 'submitted' or 'in_progress' and that is not already the current curation status
+    # But don't create the curation_activity if preserve_curation_status is set, because a user who has
+    # set that flag is expecting the curation_status to remain as whatever they have already set.
     def sync_curation_activity!
+      return if resource.preserve_curation_status
       return unless %w[in_progress submitted].include?(resource_state)
       return if resource.current_curation_activity&.status == resource_state
       StashEngine::CurationActivity.create(resource: resource, user: user, status: resource_state)

--- a/stash_engine/db/migrate/20190322184657_add_preserve_curation_status_to_resource.rb
+++ b/stash_engine/db/migrate/20190322184657_add_preserve_curation_status_to_resource.rb
@@ -1,0 +1,5 @@
+class AddPreserveCurationStatusToResource < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_resources, :preserve_curation_status, :boolean, default: false
+  end
+end


### PR DESCRIPTION
Allows API users to set a flag `preserveCurationStatus` on a resource. When this flag is active, changes to the Merritt resource_state will not affect the resource's curation status. https://github.com/CDL-Dryad/dryad-product-roadmap/issues/225

Also fixes a bug that was preventing the API from setting any curation status information.

Note there is a database migration required for this PR.

To test: submit a resource using the API, where `preserveCurationStatus` is true. Submit some curation status through the API that is not `submitted`. After being processed through Merritt, the resource should still have the appropriate curation status.