### PR TITLE
Status workflow

### DIFF
--- a/stash-merritt/spec/db/stash/merritt/repository_spec.rb
+++ b/stash-merritt/spec/db/stash/merritt/repository_spec.rb
@@ -57,6 +57,7 @@ module Stash
           tenant_id: 'dataone'
         ).build
         resource.current_state = 'processing'
+        resource.save
         @identifier = resource.identifier
 
         @doi_value = '10.15146/R3RG6G'

--- a/stash-merritt/spec/db/stash/merritt/repository_spec.rb
+++ b/stash-merritt/spec/db/stash/merritt/repository_spec.rb
@@ -94,6 +94,9 @@ module Stash
 
       describe :harvested do
         it 'sets the download URI, update URI, and status' do
+          # Skip sending emails
+          resource.skip_emails = true
+          resource.save
           repo.harvested(identifier: identifier, record_identifier: record_identifier)
           resource.reload
           expect(resource.download_uri).to eq('http://merritt.cdlib.org/d/ark%3A%2F99999%2Ffk43f5119b')

--- a/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -145,7 +145,7 @@ module StashApi
         resource = @stash_identifier.in_progress_resource
         resource.update(skip_emails: true)
         resource.current_state = 'submitted' # make it look like the first was successfully submitted, so this next will be new version
-
+        resource.save
         # this is what happens in the controller if an update to an existing identifier that has last successfully submitted (completed) version
         # I can imagine, that this might be incorporated into the DatasetParser object instead
         new_resource = resource.amoeba_dup

--- a/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -143,6 +143,7 @@ module StashApi
 
       it 'updates an existing dataset with a new in-progress version' do
         resource = @stash_identifier.in_progress_resource
+        resource.update(skip_emails: true)
         resource.current_state = 'submitted' # make it look like the first was successfully submitted, so this next will be new version
 
         # this is what happens in the controller if an update to an existing identifier that has last successfully submitted (completed) version

--- a/stash_datacite/spec/db/stash_engine/resource_spec.rb
+++ b/stash_datacite/spec/db/stash_engine/resource_spec.rb
@@ -36,7 +36,7 @@ module StashEngine
 
     describe :tenant_id do
       it 'returns the user tenant ID' do
-        resource = Resource.create(user_id: user.id, tenant_id: 'ucop')
+        resource = Resource.create(user_id: user.id, tenant_id: 'ucop', skip_emils: true)
         expect(resource.tenant_id).to eq('ucop')
       end
     end
@@ -45,7 +45,7 @@ module StashEngine
       describe :merritt_producer_download_uri do
         it 'returns the producer download URI' do
           download_uri = 'https://merritt.example.edu/d/ark%3A%2Fb5072%2Ffk2736st5z'
-          resource = Resource.create(user_id: user.id)
+          resource = Resource.create(user_id: user.id, skip_emils: true)
           resource.download_uri = download_uri
           expect(resource.merritt_producer_download_uri).to eq('https://merritt.example.edu/u/ark%3A%2Fb5072%2Ffk2736st5z/1')
         end
@@ -55,7 +55,7 @@ module StashEngine
       describe :merritt_protodomain_and_local_id do
         it 'returns the merritt protocol and domain and local ID' do
           download_uri = 'https://merritt.example.edu/d/ark%3A%2Fb5072%2Ffk2736st5z'
-          resource = Resource.create(user_id: user.id)
+          resource = Resource.create(user_id: user.id, skip_emils: true)
           resource.download_uri = download_uri
 
           merritt_protodomain, local_id = resource.merritt_protodomain_and_local_id
@@ -67,14 +67,14 @@ module StashEngine
 
     describe :dataset_in_progress_editor_id do
       it 'defaults to current_editor for no identifier' do
-        resource = Resource.create(user_id: user.id, current_editor_id: 1)
+        resource = Resource.create(user_id: user.id, current_editor_id: 1, skip_emils: true)
         expect(resource.dataset_in_progress_editor_id).to eq(1)
       end
 
       it 'gives editor id of in progress version' do
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
-        resource1 = Resource.create(user_id: user.id, identifier_id: identifier.id, current_editor_id: 1)
-        resource2 = Resource.create(user_id: user.id, identifier_id: identifier.id, current_editor_id: 2)
+        resource1 = Resource.create(user_id: user.id, identifier_id: identifier.id, current_editor_id: 1, skip_emils: true)
+        resource2 = Resource.create(user_id: user.id, identifier_id: identifier.id, current_editor_id: 2, skip_emils: true)
         state1 = ResourceState.create(user_id: 1, resource_state: 'submitted', resource_id: resource1.id)
         state2 = ResourceState.create(user_id: 2, resource_state: 'in_progress', resource_id: resource2.id)
         resource1.update(current_resource_state_id: state1.id)
@@ -89,8 +89,8 @@ module StashEngine
         user1 = User.create(tenant_id: 'ucop', first_name: 'Laura', last_name: 'Muckenhaupt')
         user2 = User.create(tenant_id: 'ucop', first_name: 'Gopher', last_name: 'Jones')
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
-        resource1 = Resource.create(user_id: user1.id, identifier_id: identifier.id, current_editor_id: user1.id)
-        resource2 = Resource.create(user_id: user1.id, identifier_id: identifier.id, current_editor_id: user2.id)
+        resource1 = Resource.create(user_id: user1.id, identifier_id: identifier.id, current_editor_id: user1.id, skip_emils: true)
+        resource2 = Resource.create(user_id: user1.id, identifier_id: identifier.id, current_editor_id: user2.id, skip_emils: true)
         state1 = ResourceState.create(user_id: 1, resource_state: 'submitted', resource_id: resource1.id)
         state2 = ResourceState.create(user_id: 2, resource_state: 'in_progress', resource_id: resource2.id)
         resource1.update(current_resource_state_id: state1.id)
@@ -107,7 +107,7 @@ module StashEngine
       attr_reader :orig_state_id
       attr_reader :orig_version
       before(:each) do
-        @resource = Resource.create(user_id: user.id)
+        @resource = Resource.create(user_id: user.id, skip_emils: true)
         @orig_state_id = resource.current_resource_state_id
         @orig_version = resource.stash_version
       end
@@ -137,7 +137,7 @@ module StashEngine
     describe 'author' do
       attr_reader :resource
       before(:each) do
-        @resource = Resource.create(user_id: user.id)
+        @resource = Resource.create(user_id: user.id, skip_emils: true)
       end
 
       it 'defaults to no authors' do
@@ -222,7 +222,7 @@ module StashEngine
       attr_reader :resource
       attr_reader :state
       before(:each) do
-        @resource = Resource.create(user_id: user.id)
+        @resource = Resource.create(user_id: user.id, skip_emils: true)
         @state = ResourceState.find_by(resource_id: resource.id)
       end
 
@@ -354,7 +354,7 @@ module StashEngine
         end
         describe :upload_dir do
           it 'returns the upload directory for this resource' do
-            resource = Resource.create
+            resource = Resource.create(skip_emils: true)
             expect(resource.upload_dir).to eq("/apps/stash/stash_engine/uploads/#{resource.id}")
           end
         end
@@ -366,7 +366,7 @@ module StashEngine
         attr_reader :copied_files
         attr_reader :deleted_files
         before(:each) do
-          @res1 = Resource.create(user_id: user.id)
+          @res1 = Resource.create(user_id: user.id, skip_emils: true)
 
           @created_files = Array.new(3) do |i|
             FileUpload.create(
@@ -395,7 +395,7 @@ module StashEngine
         end
 
         it 'defaults to empty' do
-          res2 = Resource.create(user_id: user.id)
+          res2 = Resource.create(user_id: user.id, skip_emils: true)
           expect(res2.current_file_uploads).to be_empty
         end
 
@@ -464,7 +464,7 @@ module StashEngine
 
         describe :new_file_uploads do
           it 'defaults to empty' do
-            res2 = Resource.create(user_id: user.id)
+            res2 = Resource.create(user_id: user.id, skip_emils: true)
             expect(res2.new_file_uploads).to be_empty
           end
 
@@ -483,7 +483,7 @@ module StashEngine
         attr_reader :resource
 
         before(:each) do
-          @resource = Resource.create
+          @resource = Resource.create(skip_emils: true)
           @temp_file_paths = Array.new(3) do |i|
             tempfile = Tempfile.new(["foo-#{i}", 'bin'])
             File.write(tempfile.path, '')
@@ -561,7 +561,7 @@ module StashEngine
     describe 'versioning' do
       attr_reader :resource
       before(:each) do
-        @resource = Resource.create
+        @resource = Resource.create(skip_emils: true)
       end
 
       describe :stash_version do
@@ -618,7 +618,7 @@ module StashEngine
           end
 
           it 'is incremented for the next resource' do
-            new_resource = Resource.create(identifier: resource.identifier)
+            new_resource = Resource.create(identifier: resource.identifier, skip_emils: true)
             expect(new_resource.version_number).to eq(2)
           end
         end
@@ -635,7 +635,7 @@ module StashEngine
           end
 
           it 'is incremented for the next resource' do
-            new_resource = Resource.create(identifier: resource.identifier)
+            new_resource = Resource.create(identifier: resource.identifier, skip_emils: true)
             expect(new_resource.merritt_version).to eq(2)
           end
         end
@@ -655,7 +655,7 @@ module StashEngine
         describe :latest_per_dataset do
           it 'only returns latest resources and new resources' do
             resource.dup.save
-            Resource.create
+            Resource.create(skip_emils: true)
             expect(Resource.latest_per_dataset.count).to eq(2)
           end
         end
@@ -665,7 +665,7 @@ module StashEngine
     describe 'identifiers' do
       attr_reader :resource
       before(:each) do
-        @resource = Resource.create(user_id: user.id)
+        @resource = Resource.create(user_id: user.id, skip_emils?: true)
       end
 
       describe :ensure_identifier do
@@ -751,7 +751,7 @@ module StashEngine
         end
         it 'counts published current states' do
           (0...3).each do |index|
-            resource = Resource.create(user_id: user.id)
+            resource = Resource.create(user_id: user.id, skip_emils: true)
             resource.ensure_identifier("10.123/#{index}")
             resource.current_state = 'submitted'
             resource.save
@@ -760,12 +760,12 @@ module StashEngine
         end
         it 'groups by identifier' do
           (0...3).each do |_index|
-            res1 = Resource.create(user_id: user.id)
+            res1 = Resource.create(user_id: user.id, skip_emils: true)
             res1.ensure_identifier('10.123/456')
             res1.current_state = 'submitted'
             res1.save
 
-            res2 = Resource.create(user_id: user.id)
+            res2 = Resource.create(user_id: user.id, skip_emils: true)
             res2.ensure_identifier('10.345/678')
             res2.current_state = 'submitted'
             res2.save
@@ -775,7 +775,7 @@ module StashEngine
 
         it 'doesn\'t count non-published datasets' do
           %w[in_progress processing error].each_with_index do |state, index|
-            resource = Resource.create(user_id: user.id)
+            resource = Resource.create(user_id: user.id, skip_emils: true)
             resource.ensure_identifier("10.123/#{index}")
             resource.current_state = state
             resource.save
@@ -784,7 +784,7 @@ module StashEngine
         end
         it 'doesn\'t count non-current states' do
           %w[in_progress processing error].each_with_index do |state, index|
-            resource = Resource.create(user_id: user.id)
+            resource = Resource.create(user_id: user.id, skip_emils: true)
             resource.ensure_identifier("10.123/#{index}")
             resource.current_state = 'submitted'
             resource.current_state = state

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -18,7 +18,6 @@ module StashEngine
       my_tenant_id = (current_user.role == 'admin' ? current_user.tenant_id : nil)
       @all_stats = Stats.new
       @seven_day_stats = Stats.new(tenant_id: my_tenant_id, since: (Time.new - 7.days))
-
       @resources = build_table_query
       respond_to do |format|
         format.html
@@ -43,7 +42,7 @@ module StashEngine
     # Unobtrusive Javascript (UJS) to do AJAX by running javascript
     def note_popup
       respond_to do |format|
-        resource = Resource.includes(:identifier, :current_curation_activity).find(params[:id])
+        resource = Resource.includes(:identifier, :curation_activities).find(params[:id])
         @curation_activity = CurationActivity.new(
           resource_id: resource.id,
           status: resource.current_curation_activity.status
@@ -55,24 +54,27 @@ module StashEngine
     # Unobtrusive Javascript (UJS) to do AJAX by running javascript
     def curation_activity_popup
       respond_to do |format|
-        @resource = Resource.includes(:identifier, :current_curation_activity).find(params[:id])
+        @resource = Resource.includes(:identifier, :curation_activities).find(params[:id])
         @curation_activity = StashEngine::CurationActivity.new(resource_id: @resource.id)
         format.js
       end
     end
 
+    # rubocop#disable Metrics/MethodLength
     def curation_activity_change
       respond_to do |format|
         format.js do
           @resource = Resource.find(params[:id])
           decipher_curation_activity
-          @resource.update(publication_date: @pub_date)
-          CurationActivity.create(resource_id: @resource.id, user_id: current_user.id,
-                                  status: @status, note: params[:resource][:curation_activity][:note])
+          @resource.publication_date = @pub_date
+          @resource.curation_activities << CurationActivity.create(user_id: current_user.id, status: @status,
+                                                                   note: params[:resource][:curation_activity][:note])
+          @resource.save
           @resource.reload
         end
       end
     end
+    # rubocop#enable Metrics/MethodLength
 
     # show curation activities for this item
     def activity_log
@@ -117,8 +119,8 @@ module StashEngine
       # Retrieve the ids of the all the latest Resources
       resource_ids = Resource.latest_per_dataset.pluck(:id)
 
-      resources = Resource.joins(:identifier, :authors, :current_resource_state, :current_curation_activity)
-        .includes(:identifier, :authors, :current_resource_state, current_curation_activity: :user)
+      resources = Resource.joins(:identifier, :authors, :current_resource_state, :curation_activities)
+        .includes(:identifier, :authors, :current_resource_state, curation_activities: :user)
         .where(stash_engine_resources: { id: resource_ids })
 
       # If the user is not a super_admin restrict their access to their tenant
@@ -167,7 +169,7 @@ module StashEngine
       @status = params[:resource][:curation_activity][:status]
       @pub_date = params[:resource][:publication_date]
       # If the status was nil then we are just adding a note so get the prior status
-      @status = @resource.current_curation_activity.status unless @status.present?
+      @status = @resource.current_curation_status unless @status.present?
       case @status
       when 'published'
         publish

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -60,7 +60,7 @@ module StashEngine
       end
     end
 
-    # rubocop#disable Metrics/MethodLength
+    # rubocop:disable Metrics/MethodLength
     def curation_activity_change
       respond_to do |format|
         format.js do
@@ -74,7 +74,7 @@ module StashEngine
         end
       end
     end
-    # rubocop#enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength
 
     # show curation activities for this item
     def activity_log

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -22,12 +22,9 @@ module StashEngine
     def curation_note
       # only add to latest resource and after latest curation activity, no matter if this page is stale or whatever
       @resource = Identifier.find_by_id(params[:id]).latest_resource
-      @curation_activity = CurationActivity.create(
-        status: @resource.current_curation_activity.status,
-        note: params[:curation_activity][:note],
-        resource_id: @resource.id,
-        user_id: current_user.id
-      )
+      CurationActivity.create(resource_id: @resource.id, status: @resource.current_curation_activity.status,
+                              note: params[:curation_activity][:note], user_id: current_user.id)
+      @resource.reload
     end
 
     private

--- a/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/curation_activity_controller.rb
@@ -22,8 +22,9 @@ module StashEngine
     def curation_note
       # only add to latest resource and after latest curation activity, no matter if this page is stale or whatever
       @resource = Identifier.find_by_id(params[:id]).latest_resource
-      CurationActivity.create(resource_id: @resource.id, status: @resource.current_curation_activity.status,
-                              note: params[:curation_activity][:note], user_id: current_user.id)
+      @curation_activity = CurationActivity.create(resource_id: @resource.id, user_id: current_user.id,
+                                                   status: @resource.current_curation_activity.status,
+                                                   note: params[:curation_activity][:note])
       @resource.reload
     end
 

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -63,9 +63,6 @@ module StashEngine
     after_create :email_orcid_invitations,
                  if: proc { |ca| ca.published? && latest_curation_status_changed? && !resource.skip_emails }
 
-    after_create :update_resource_reference!
-    after_destroy :remove_resource_reference!
-
     # Class methods
     # ------------------------------------------
     # Translates the enum value to a human readable status
@@ -116,16 +113,6 @@ module StashEngine
 
     # Callbacks
     # ------------------------------------------
-    def update_resource_reference!
-      StashEngine::Resource.find(resource_id).update(current_curation_activity_id: id)
-    end
-
-    def remove_resource_reference!
-      # Reverts the current_curation_activity pointer on Resource to the prior activity
-      prior = CurationActivity.where(resource_id: resource_id).where.not(id: id).order(updated_at: :desc).first
-      StashEngine::Resource.find(resource_id).update(current_curation_activity_id: prior&.id || '')
-    end
-
     def submit_to_stripe
       return unless ready_for_payment? &&
                     resource.identifier&.user_must_pay?

--- a/stash_engine/app/models/stash_engine/resource_state.rb
+++ b/stash_engine/app/models/stash_engine/resource_state.rb
@@ -6,20 +6,5 @@ module StashEngine
 
     enum resource_state: %w[in_progress processing submitted error].map { |i| [i.to_sym, i] }.to_h
     validates :resource_state, presence: true
-
-    after_save :sync_curation_activity!
-
-    private
-
-    # Add a record to the CurationActivities for the Resource IF the new resource_state
-    # is 'submitted' or 'in_progress' and that is not already the current curation status
-    # But don't create the curation_activity if preserve_curation_status is set, because a user who has
-    # set that flag is expecting the curation_status to remain as whatever they have already set.
-    def sync_curation_activity!
-      return if resource.preserve_curation_status
-      return unless %w[in_progress submitted].include?(resource_state)
-      return if resource.current_curation_activity&.status == resource_state
-      StashEngine::CurationActivity.create(resource: resource, user: user, status: resource_state)
-    end
   end
 end

--- a/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
@@ -8,7 +8,7 @@
       <%= f.fields_for :curation_activity, curation_activity do |ca| %>
         <div class="c-input">
           <label class="c-input__label">Status</label>
-          <%= ca.select :status, options_for_select(filter_status_select(@resource.current_curation_activity.status)), include_blank: true %>
+          <%= ca.select :status, options_for_select(filter_status_select(@resource.current_curation_status)), include_blank: true %>
         </div>
       <% end %>
 

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -36,18 +36,15 @@
         <%= link_to resource.title, show_path(id: identifier.to_s, latest: true), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left">
-        <% if resource&.submitted? || resource&.dataset_in_progress_editor&.id == current_user.id %>
-          <%= form_tag(metadata_entry_pages_new_version_path, method: :post) do -%>
-            <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
-            <%= hidden_field_tag :resource_id, resource.id %>
-          <% end %>
+        <% if resource&.current_curation_status == 'curation' || resource&.dataset_in_progress_editor&.id == current_user.id %>
+          <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: resource.id } %>
         <% end %>
       </td>
       <td class="c-admin-hide-border-right" id="js-curation-state-<%= identifier.id %>">
         <%= latest_curation_activity.readable_status %>
       </td>
       <td class="c-admin-hide-border-left">
-        <% if current_user.role == 'superuser' && resource.curatable? %>
+        <% if %w[admin superuser].include?(current_user.role) && resource.curatable? %>
           <%= form_tag({ controller: '/stash_engine/admin_datasets',
                          action: 'curation_activity_popup', id: resource.id },
                          method: :get, remote: true) do -%>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -29,19 +29,18 @@
 
   <% resources.each do |resource| %>
     <% identifier = resource.identifier %>
-    <% latest_curation_activity = resource.current_curation_activity %>
 
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
         <%= link_to resource.title, show_path(id: identifier.to_s, latest: true), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left">
-        <% if resource&.current_curation_status == 'curation' || resource&.dataset_in_progress_editor&.id == current_user.id %>
+        <% if resource&.current_curation_activity.curation? || resource&.dataset_in_progress_editor&.id == current_user.id %>
           <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: resource.id } %>
         <% end %>
       </td>
       <td class="c-admin-hide-border-right" id="js-curation-state-<%= identifier.id %>">
-        <%= latest_curation_activity.readable_status %>
+        <%= resource.current_curation_activity.readable_status %>
       </td>
       <td class="c-admin-hide-border-left">
         <% if %w[admin superuser].include?(current_user.role) && resource.curatable? %>
@@ -57,7 +56,7 @@
       <td><%= resource&.authors.first&.author_standard_name %></td>
       <td><%= identifier.identifier %></td>
       <td class="c-admin-hide-border-right" id="js-curation-activity-date-<%= identifier.id %>">
-        <%= formatted_datetime(latest_curation_activity.updated_at) %>
+        <%= formatted_datetime(resource.current_curation_activity.updated_at) %>
       </td>
       <td class="c-admin-hide-border-left">
         <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'activity_log', id: identifier.id }, method: :get) do -%>
@@ -66,7 +65,7 @@
           </button>
         <% end %>
       </td>
-      <td id="js-curation-activity-user-<%= identifier.id %>"><%= latest_curation_activity.user&.name %></td>
+      <td id="js-curation-activity-user-<%= identifier.id %>"><%= resource.current_curation_activity.user&.name %></td>
       <td><%= filesize(identifier.storage_size) %></td>
       <td class="c-admin" id="js-embargo-state-<%= identifier.id %>">
         <%= formatted_date(resource&.publication_date) %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_edit_dataset_button.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag(metadata_entry_pages_new_version_path, method: :post) do -%>
+  <button class="c-admin-edit-icon" title="Edit Dataset"><i class="fa fa-pencil" aria-hidden="true"></i></button>
+  <%= hidden_field_tag :resource_id, resource_id %>
+<% end %>

--- a/stash_engine/config/routes.rb
+++ b/stash_engine/config/routes.rb
@@ -104,6 +104,6 @@ StashEngine::Engine.routes.draw do
   get 'admin/user_dashboard/:id', to: 'admin#user_dashboard', as: 'admin_user_dashboard'
 
   # admin_datasets, this routes actions to ds_admin with a possible id without having to define for each get action, default is index
-  get 'ds_admin/(:action(/:id))', to: 'admin_datasets'
+  get 'ds_admin/(:action(/:id))', controller: 'admin_datasets'
 
 end

--- a/stash_engine/lib/stash/repo/repository.rb
+++ b/stash_engine/lib/stash/repo/repository.rb
@@ -66,8 +66,8 @@ module Stash
 
         resource.download_uri = get_download_uri(resource, record_identifier)
         resource.update_uri = get_update_uri(resource, record_identifier)
+        resource.save # current_state calls :reload so we need to save first!
         resource.current_state = 'submitted'
-        resource.save
 
         # Keep files until they've been successfully confirmed in the OAI-PMH feed, don't aggressively clean up until then
         # cleanup_files(resource)

--- a/stash_engine/lib/stash/repo/repository.rb
+++ b/stash_engine/lib/stash/repo/repository.rb
@@ -66,9 +66,8 @@ module Stash
 
         resource.download_uri = get_download_uri(resource, record_identifier)
         resource.update_uri = get_update_uri(resource, record_identifier)
-        resource.save # current_state calls :reload so we need to save first!
         resource.current_state = 'submitted'
-
+        resource.save
         # Keep files until they've been successfully confirmed in the OAI-PMH feed, don't aggressively clean up until then
         # cleanup_files(resource)
       end
@@ -101,13 +100,13 @@ module Stash
 
       def handle_success(result)
         result.log_to(log)
-        # resource.current_state = 'submitted'
         update_submission_log(result)
       rescue StandardError => e
         # errors here don't constitute a submission failure, so we don't change the resource state
         log_error(e)
       end
 
+      # rubcop:disable Metrics/MethodLength
       def handle_failure(result)
         result.log_to(log)
         update_submission_log(result)
@@ -117,8 +116,9 @@ module Stash
       rescue StandardError => e
         log_error(e)
       ensure
-        resource.current_state = 'error' if resource
+        resource.current_state = 'error' if resource.present?
       end
+      # rubcop:enable Metrics/MethodLength
 
       def log_error(error)
         log.error(to_msg(error))

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -73,24 +73,6 @@ module StashEngine
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_via_invoice).and_return(true)
       end
 
-      it 'updates the resources.current_curation_activity_id when creating a new record' do
-        ca = CurationActivity.create(resource_id: @resource.id)
-        expect(@resource.reload.current_curation_activity_id).to eql(ca.id)
-      end
-
-      it 'removes the resources.current_curation_activity_id when the record is deleted and no prior curation activity exists' do
-        @resource.current_curation_activity.destroy
-        expect(@resource.reload.current_curation_activity_id).to eql(nil)
-      end
-
-      it 'updates the resources.current_curation_activity_id to the prior curation activity when the record is removed' do
-        original = @resource.current_curation_activity_id
-        ca = CurationActivity.create(resource_id: @resource.id, status: 'submitted')
-
-        ca.destroy
-        expect(@resource.reload.current_curation_activity_id).to eql(original)
-      end
-
       context :update_solr do
 
         it 'calls update_solr when published' do

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -182,7 +182,7 @@ module StashEngine
 
         StashEngine::CurationActivity.statuses.each do |status|
 
-          if %w[peer_review submitted published embargoed].include?(status)
+          if %w[published embargoed].include?(status)
             it "calls email_author when '#{status}'" do
               allow_any_instance_of(StashEngine::CurationActivity).to receive(:email_author?).and_return(false)
               ca = CurationActivity.new(resource_id: @resource.id, status: status)

--- a/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -1,9 +1,11 @@
 require 'db_spec_helper'
 
 module StashEngine
-  describe Resource do
-    attr_reader :user
 
+  describe Resource do
+
+    attr_reader :user
+    attr_reader :skip_emails
     attr_reader :future_date
 
     before(:all) do
@@ -40,7 +42,8 @@ module StashEngine
     describe :can_edit do
       it 'returns false if editing by someone else' do
         identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
-        resource = Resource.create(user_id: user.id, identifier_id: identifier.id, current_editor_id: @user.id + 1, tenant_id: 'ucop')
+        resource = Resource.create(user_id: user.id, identifier_id: identifier.id,
+                                   current_editor_id: @user.id + 1, tenant_id: 'ucop')
         ResourceState.create(user_id: @user.id + 1, resource_state: 'in_progress', resource_id: resource.id)
         User.create(first_name: 'L',
                     last_name: 'Mu',
@@ -529,6 +532,16 @@ module StashEngine
             res1.current_state = 'error'
             expect(res1.current_state).to eq('error')
             expect(resource.current_state).to eq('submitted')
+          end
+          it 'does not call prepare_for_curation when :in_progess' do
+            resource.preserve_curation_status = true
+            expect(resource).not_to receive(:prepare_for_curation)
+            resource.current_state = 'in_progress'
+          end
+          it 'does not call prepare_for_curation when `preserve_curation_status == true`' do
+            resource.preserve_curation_status = true
+            expect(resource).not_to receive(:prepare_for_curation)
+            resource.current_state = 'submitted'
           end
         end
       end
@@ -1123,6 +1136,32 @@ module StashEngine
         end
 
       end
+
+      describe :prepare_for_curation do
+
+        before(:each) do
+          @resource = Resource.create(user_id: user.id)
+        end
+
+        it 'sets the current_curation_status to :submitted when it is the initial version' do
+          @resource.current_state = 'submitted'
+          expect(@resource.current_curation_status).to eql('submitted')
+        end
+
+        it 'assigns the resource.user_id to the curation_activity when no editor is defined' do
+          @resource.current_state = 'submitted'
+          expect(@resource.current_curation_status).to eql('submitted')
+          expect(@resource.current_curation_activity.user_id).to eql(@resource.user_id)
+        end
+
+        it 'assigns the resource.current_editor_id to the curation_activity when an editor is defined' do
+
+        end
+
+      end
+
     end
+
   end
+
 end

--- a/stash_engine/spec/db/stash_engine/resource_state_spec.rb
+++ b/stash_engine/spec/db/stash_engine/resource_state_spec.rb
@@ -3,45 +3,5 @@ require 'db_spec_helper'
 module StashEngine
   describe ResourceState do
 
-    before(:each) do
-      @identifier = StashEngine::Identifier.create(identifier_type: 'DOI', identifier: '10.123/123')
-      @resource = StashEngine::Resource.create(identifier_id: @identifier.id)
-    end
-
-    context :callbacks do
-
-      it 'creates a CurationActivity when resource_state is "submitted"' do
-        original = @resource.current_resource_state
-        original.update(resource_state: 'submitted')
-        @resource.reload
-        expect(@resource.curation_activities.length).to eql(2)
-        expect(@resource.current_curation_status).to eql('submitted')
-      end
-
-      it 'creates a CurationActivity when the resource_state is "in_progress"' do
-        original = @resource.current_resource_state
-        original.update(resource_state: 'submitted')
-        ResourceState.create(resource_id: @resource.id, resource_state: 'in_progress')
-        @resource.reload
-        expect(@resource.curation_activities.length).to eql(3)
-        expect(@resource.current_curation_status).to eql('in_progress')
-      end
-
-      it 'cadoes NOT create a CurationActivity record when resource_state is "error" or "processing"' do
-        original = @resource.current_resource_state
-        original.update(resource_state: 'error')
-        @resource.reload
-        expect(@resource.curation_activities.length).to eql(1)
-        expect(@resource.current_curation_status).to eql('in_progress')
-
-        original = @resource.current_resource_state
-        original.update(resource_state: 'processing')
-        @resource.reload
-        expect(@resource.curation_activities.length).to eql(1)
-        expect(@resource.current_curation_status).to eql('in_progress')
-      end
-
-    end
-
   end
 end

--- a/stash_engine/spec/db/stash_engine/user_spec.rb
+++ b/stash_engine/spec/db/stash_engine/user_spec.rb
@@ -72,7 +72,7 @@ module StashEngine
 
       it 'finds the user\'s resources' do
         resources = Array.new(5) do |index|
-          resource = Resource.create(user_id: user.id)
+          resource = Resource.create(user_id: user.id, skip_emails: true)
           resource.current_state = 'submitted'
           resource.ensure_identifier("10.123/#{index}")
           resource
@@ -86,11 +86,11 @@ module StashEngine
         other = []
         %w[submitted processing].each_with_index do |state, index|
           doi_value = "10.123/#{index}"
-          res1 = Resource.create(user_id: user.id)
+          res1 = Resource.create(user_id: user.id, skip_emails: true)
           res1.ensure_identifier(doi_value)
           res1.current_state = 'in_progress'
           in_progress << res1
-          res2 = Resource.create(user_id: user.id)
+          res2 = Resource.create(user_id: user.id, skip_emails: true)
           res2.ensure_identifier(doi_value)
           res2.current_state = state
           other << res2
@@ -105,7 +105,7 @@ module StashEngine
       it 'finds only the latest for each identifier' do
         resources = Array.new(5) do |_|
           doi_value = '10.123/1234'
-          resource = Resource.create(user_id: user.id)
+          resource = Resource.create(user_id: user.id, skip_emails: true)
           resource.current_state = 'submitted'
           resource.ensure_identifier(doi_value)
           resource


### PR DESCRIPTION
Reconfigured relationship between Resource and CurationActivity. Removed callbacks that were managing curation status.

Updated one of the stash_engine routes which was throwing a deprecation warning.

Added a bunch of tests to Dryad repo to verify that these changes are working and that resource versioning functions properly.