### PR TITLE
Fix for bug causing 2 emails to be sent to author when publishing a dataset

### DIFF
--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -126,8 +126,7 @@ module StashEngine
       idg = Stash::Doi::IdGen.make_instance(resource: resource)
       idg.update_identifier_metadata!
 
-      # Send out emails now that the citation has been registered
-      email_author if published?
+      # Send out orcid invitations now that the citation has been registered
       email_orcid_invitations if published?
     end
 


### PR DESCRIPTION
Callback on CurationActivity is already triggered so removing the call within the submit_datacite method