### PR TITLE
Update Stripe to use author email 

### DIFF
--- a/stash_datacite/spec/db/stash_datacite/author_spec.rb
+++ b/stash_datacite/spec/db/stash_datacite/author_spec.rb
@@ -26,6 +26,26 @@ module StashEngine # TODO: are we testing Author or Affiliation? (Or AuthorPatch
       end
     end
 
+    describe 'emails' do
+      before(:each) do
+        @auth = Author.new(resource_id: resource.id, author_first_name: 'Jane', author_last_name: 'Doe')
+      end
+      it 'does not require email' do
+        expect(@auth.valid?).to eql(true)
+        expect(@auth.errors.empty?).to eql(true)
+      end
+      it 'validates email format' do
+        %w[abcdefg abcdefg@bademail abcdefg@bademail,bademl @bad.eml abcdefgbad.eml].each do |email|
+          @auth.author_email = email
+          expect(@auth.valid?).to eql(false), "expected '#{email}' to be invalid"
+          expect(@auth.errors[:author_email].first).to eql('is invalid')
+        end
+        @auth.author_email = 'abcdefg@bad.eml'
+        expect(@auth.valid?).to eql(true)
+        expect(@auth.errors.empty?).to eql(true)
+      end
+    end
+
     describe 'affiliations' do
       attr_reader :affiliations
       before(:each) do

--- a/stash_engine/app/models/stash_engine/author.rb
+++ b/stash_engine/app/models/stash_engine/author.rb
@@ -14,6 +14,7 @@ module StashEngine
     before_save :strip_whitespace
 
     scope :names_filled, -> { where("TRIM(IFNULL(author_first_name,'')) <> '' AND TRIM(IFNULL(author_last_name,'')) <> ''") }
+    scope :primary, ->(resource_id) { where(resource_id: resource_id).where.not(author_email: nil).order(:id).first }
 
     amoeba do
       enable

--- a/stash_engine/db/migrate/20190410162918_move_customer_id_from_stash_engine_users_to_stash_engine_authors.rb
+++ b/stash_engine/db/migrate/20190410162918_move_customer_id_from_stash_engine_users_to_stash_engine_authors.rb
@@ -1,0 +1,6 @@
+class MoveCustomerIdFromStashEngineUsersToStashEngineAuthors < ActiveRecord::Migration
+  def change
+    remove_column :stash_engine_users, :customer_id
+    add_column :stash_engine_authors, :stripe_customer_id, :text
+  end
+end

--- a/stash_engine/spec/db/stash_engine/author_spec.rb
+++ b/stash_engine/spec/db/stash_engine/author_spec.rb
@@ -151,6 +151,13 @@ module StashEngine
           end
         end
 
+        it 'primary returns correct author' do
+          Author.create(resource_id: resource.id, author_first_name: 'Wrong')
+          right_author = Author.create(resource_id: resource.id, author_first_name: 'Right', author_email: 'right@one.org')
+          Author.create(resource_id: resource.id, author_first_name: 'Wrong2')
+          expect(Author.primary(resource.id)).to eql(right_author)
+        end
+
       end
     end
   end

--- a/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -1,0 +1,61 @@
+require 'ostruct'
+require 'spec_helper'
+require_relative '../../../../lib/stash/payments/invoicer'
+
+module Stash
+  module Payments
+    describe Invoicer do
+
+      before(:each) do
+        @identifier = double(StashEngine::Identifier)
+        allow(@identifier).to receive(:to_s).and_return('doi:10.123/a1b.c2d3')
+        allow(@identifier).to receive(:invoice_id=)
+        allow(@identifier).to receive(:save).and_return(true)
+
+        @resource_id = 17
+        @resource = double(StashEngine::Resource)
+        allow(StashEngine::Resource).to receive(:find).with(@resource_id).and_return(@resource)
+        allow(@resource).to receive(:authors).and_return([@author])
+        allow(@resource).to receive(:id).and_return(@resource_id)
+        allow(@resource).to receive(:title).and_return('My Test Dataset')
+        allow(@resource).to receive(:identifier).and_return(@identifier)
+
+        @author = double(StashEngine::Author)
+        allow(StashEngine::Author).to receive(:primary).with(@resource_id).and_return(@author)
+        allow(StashEngine::Author).to receive(:where).and_return(nil)
+        allow(@author).to receive(:update).and_return(true)
+        allow(@author).to receive(:id).and_return(9)
+        allow(@author).to receive(:author_email).and_return('jane.doe@example.org')
+        allow(@author).to receive(:author_standard_name).and_return('Jane Doe')
+
+        @cust_id = '9999'
+        fake_invoice_item = OpenStruct.new(customer: @cust_id, amount: '99.99', currency: 'usd', description: 'Data Processing Charge')
+        fake_invoice = OpenStruct.new(customer: @cust_id, description: 'Dryad deposit',
+                                      metadata: { curator: 'The Curator' }, finalize_invoice: 'STRIPE1234')
+        fake_customer = OpenStruct.new(id: @cust_id, email: @author.author_email, description: @author.author_standard_name)
+
+        @invoicer = Invoicer.new(resource: @resource, curator: @curator)
+        allow(@invoicer).to receive(:set_api_key).and_return(true)
+        allow(@invoicer).to receive(:add_dpc).and_return(fake_invoice_item)
+        allow(@invoicer).to receive(:create_invoice).and_return(fake_invoice)
+        allow(@invoicer).to receive(:create_customer).and_return(fake_customer)
+        allow(@invoicer).to receive(:lookup_prior_stripe_customer_id).and_return(nil)
+      end
+
+      it 'creates an invoice for a new stripe customer' do
+        expect(@invoicer.charge_via_invoice).to eql('STRIPE1234')
+      end
+
+      it 'creates an invoice for an existing stripe customer' do
+        allow(@invoicer).to receive(:lookup_prior_stripe_customer_id).and_return('999911')
+        expect(@invoicer.charge_via_invoice).to eql('STRIPE1234')
+      end
+
+      it 'does not create an invoice when the resource has no primary author' do
+        allow(StashEngine::Author).to receive(:primary).with(@resource_id).and_return(nil)
+        expect(@invoicer.charge_via_invoice).to eql(nil)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
- added migration to remove `stash_engine_users.customer_id` and add `stash_engine_authors.stripe_customer_id`
- added `StashEngine::Author.primary(resource_id)` scope that returns the first Author that has an email (UI already verifies that there is at least one with email)
- refactored `Stash::Payments::Invoicer` to work with authors instead of user
- refactored `Stash::Payments::Invoicer` to encapsulate Stripe calls (was really just an easy way to double/mock Stripe)
- Added tests for `Stash::Payments::Invoicer` to test scenarios: A) No authors for some reason, B) Author that has never had a Stripe invoice from us, C) Author who has already had a Stripe invoice from us