### PR TITLE
Add invoiceId to the API for creating new datasets

### DIFF
--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -175,6 +175,7 @@ module StashApi
       # all this bogus return false stuff is to prevent double render errors in some circumstances
       return if check_superuser_restricted_params == false
       return if check_may_set_user_id == false
+      return if check_may_set_invoice_id == false
     end
 
     def check_superuser_restricted_params
@@ -200,6 +201,15 @@ module StashApi
       users = StashEngine::User.where(id: params['userId'])
       return if users.count == 1
       render(json: { error: 'Bad Request: the userId you chose is invalid' }.to_json, status: 400)
+      false
+    end
+
+    def check_may_set_invoice_id
+      return if params['invoiceId'].nil?
+      unless @user.role == 'superuser'
+        render json: { error: 'Unauthorized: only superuser roles may set an invoiceId' }.to_json, status: 401
+        return false
+      end
       false
     end
 

--- a/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash_api/app/models/stash_api/dataset_parser.rb
@@ -35,7 +35,7 @@ module StashApi
       @hash[:authors]&.each { |author| add_author(json_author: author) }
       StashDatacite::Description.create(description: @hash[:abstract], description_type: 'abstract', resource_id: @resource.id)
       TO_PARSE.each { |item| dynamic_parse(my_class: item) }
-      @resource.identifier.invoice_id = @hash['invoiceID']
+      @resource.identifier.invoice_id = @hash['invoiceId']
       @resource.identifier.save
       @resource.identifier
     end

--- a/stash_api/app/models/stash_api/dataset_parser.rb
+++ b/stash_api/app/models/stash_api/dataset_parser.rb
@@ -35,6 +35,8 @@ module StashApi
       @hash[:authors]&.each { |author| add_author(json_author: author) }
       StashDatacite::Description.create(description: @hash[:abstract], description_type: 'abstract', resource_id: @resource.id)
       TO_PARSE.each { |item| dynamic_parse(my_class: item) }
+      @resource.identifier.invoice_id = @hash['invoiceID']
+      @resource.identifier.save
       @resource.identifier
     end
 

--- a/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -45,7 +45,8 @@ module StashApi
         ],
         'abstract' =>
               'Cyberneticists agree that concurrent models are an interesting new topic in the field of machine learning.',
-        'userId' => @user2.id
+        'userId' => @user2.id,
+        'invoiceId' => 'invoice-123'
       }.with_indifferent_access
 
       @update_metadata = {
@@ -130,6 +131,9 @@ module StashApi
         expect(resource.current_editor_id).to eq(@user2.id)
       end
 
+      it 'puts the invoiceID on the identifier' do
+        expect(@stash_identifier.invoice_id). to eq('invoice-123')
+      end
     end
 
     describe 'identifier handling' do

--- a/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_parser_spec.rb
@@ -131,7 +131,7 @@ module StashApi
         expect(resource.current_editor_id).to eq(@user2.id)
       end
 
-      it 'puts the invoiceID on the identifier' do
+      it 'puts the invoiceId on the identifier' do
         expect(@stash_identifier.invoice_id). to eq('invoice-123')
       end
     end


### PR DESCRIPTION

When creating a new dataset, allow API superusers to specify an `invoiceId`, which will be stored in the identifier.invoice_id field.

This  is needed to migrate content from the old Dryad system, most of which has already been invoiced/paid.