### PR TITLE
Bugfix: set date when API call doesn't have created_at

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -81,11 +81,11 @@ module StashApi
                                            user_id: params[:user_id] || @user.id,
                                            status: params[:curation_activity][:status],
                                            note: params[:curation_activity][:note],
-                                           created_at: params[:curation_activity][:created_at] || date)
+                                           created_at: params[:curation_activity][:created_at] || Time.now)
     end
 
     def record_published_date(resource)
-      publish_date = params[:curation_activity][:created_at] || date
+      publish_date = params[:curation_activity][:created_at] || Time.now
       resource.update!(publication_date: publish_date)
     end
 


### PR DESCRIPTION
Somehow these two lines were using a non-existent `date` variable. Replacing it with a valid date.