### PR TITLE
Remove errors when viewing an item in a user workspace

### DIFF
--- a/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -35,7 +35,7 @@ module StashEngine
         if params[:latest] == 'true' && current_user&.superuser? # let superusers see the latest, unpublished if they wish
           id.resources.by_version_desc.first
         # let user see his own if logged in or let superuser see non-latest-preview stuff
-        elsif (current_user && (current_user.id == id.resources.submitted.by_version_desc.first.user_id)) || current_user&.superuser?
+        elsif (current_user && (current_user.id == id.resources.submitted&.by_version_desc&.first&.user_id)) || current_user&.superuser?
           id.resources.submitted.by_version_desc.first
         else # everyone else only gets to see published or embargoed metadata latest version
           id.latest_resource_with_public_metadata

--- a/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -54,9 +54,7 @@ module StashEngine
     # Actions
 
     def show
-      if resource.metadata_published?
-        CounterLogger.general_hit(request: request, resource: resource)
-      end
+      CounterLogger.general_hit(request: request, resource: resource) if resource.metadata_published?
       ensure_has_geolocation!
       @invitations = (params[:invitation] ? OrcidInvitation.where(secret: params[:invitation]).where(identifier_id: id.id) : nil)
     end

--- a/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -54,7 +54,9 @@ module StashEngine
     # Actions
 
     def show
-      CounterLogger.general_hit(request: request, resource: resource)
+      if resource.metadata_published?
+        CounterLogger.general_hit(request: request, resource: resource)
+      end
       ensure_has_geolocation!
       @invitations = (params[:invitation] ? OrcidInvitation.where(secret: params[:invitation]).where(identifier_id: id.id) : nil)
     end


### PR DESCRIPTION
As a superuser, try to view the landing page for an item that is in another user's workspace. You will receive a null pointer error or InvalidComponentError unless this fix is in place.