### PR TITLE
Updates to landing page to use publication_date instead of updated_at

### DIFF
--- a/stash_datacite/app/controllers/stash_datacite/landing_mixin.rb
+++ b/stash_datacite/app/controllers/stash_datacite/landing_mixin.rb
@@ -50,9 +50,9 @@ module StashDatacite
     end
 
     # rubocop:disable Metrics/ParameterLists
-    def citation(authors, title, resource_type, version, identifier, publisher, publication_years)
+    def citation(authors, title, resource_type, version, identifier, publisher, publication_year)
       citation = []
-      citation << h("#{author_citation_format(authors)} (#{pub_year_from(publication_years)})")
+      citation << h("#{author_citation_format(authors)} (#{publication_year})")
       citation << h(title)
       citation << h(version == 'v1' ? '' : version)
       citation << h(publisher.try(:publisher))

--- a/stash_datacite/app/controllers/stash_datacite/landing_mixin.rb
+++ b/stash_datacite/app/controllers/stash_datacite/landing_mixin.rb
@@ -71,10 +71,6 @@ module StashDatacite
       str_author.join('; ')
     end
 
-    def pub_year_from(publication_years)
-      publication_years.try(:first).try(:publication_year) || Time.now.year
-    end
-
     def schema_org_json_for(resource)
       ds_presenter = StashDatacite::ResourcesController::DatasetPresenter.new(resource)
       landing_page_url = stash_url_helpers.show_url(ds_presenter.external_identifier, host: request.host)

--- a/stash_datacite/app/helpers/stash_datacite/resources_helper.rb
+++ b/stash_datacite/app/helpers/stash_datacite/resources_helper.rb
@@ -1,8 +1,8 @@
 module StashDatacite
   module ResourcesHelper
-    def citation(authors, title, resource_type, version, identifier, publisher, publication_years) # rubocop:disable Metrics/ParameterLists
+    def citation(authors, title, resource_type, version, identifier, publisher, publication_year) # rubocop:disable Metrics/ParameterLists
       [
-        "#{author_citation_format(authors)} (#{pub_year_from(publication_years)})",
+        "#{author_citation_format(authors)} (#{publication_year})",
         escape_title(title),
         escape_version(version),
         escape_publisher(publisher),
@@ -29,6 +29,7 @@ module StashDatacite
     private
 
     def pub_year_from(publication_years)
+      return publication_years.year if publication_years.is_a?(Date)
       publication_years.try(:first).try(:publication_year) || Time.now.year
     end
 

--- a/stash_datacite/app/helpers/stash_datacite/resources_helper.rb
+++ b/stash_datacite/app/helpers/stash_datacite/resources_helper.rb
@@ -28,11 +28,6 @@ module StashDatacite
 
     private
 
-    def pub_year_from(publication_years)
-      return publication_years.year if publication_years.is_a?(Date)
-      publication_years.try(:first).try(:publication_year) || Time.now.year
-    end
-
     def escape_title(title)
       html_escape(title)
     end

--- a/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -15,7 +15,7 @@
                          resource_type: @review.resource_type, version: "v#{@resource.version_number}",
                          identifier: @resource.identifier.nil? ? nil : "#{@review.identifier.identifier}",
                          publisher: @review.publisher,
-                         publication_years: @resource.publication_years } %>
+                         publication_year: (@resource.publication_date.present? ? @resource.publication_date.year : @resource.updated_at.year) } %>
     </section>
 
     <%= render partial: "stash_datacite/descriptions/show", locals:

--- a/stash_datacite/app/views/stash_datacite/resources/_show.html.erb
+++ b/stash_datacite/app/views/stash_datacite/resources/_show.html.erb
@@ -14,7 +14,7 @@
                        version: resource.stash_version.nil? ? 'v0' : "v#{review.version.version }",
                        identifier: resource.identifier.nil? ? 'DOI' : "#{review.identifier.identifier }",
                        publisher: review.publisher,
-                       publication_years: resource.publication_years } %>
+                       publication_year: (resource.publication_date.present? ? resource.publication_date.year : resource.updated_at.year) } %>
   </section>
   <%= render partial: "stash_datacite/descriptions/show", locals: { abstract: review.abstract,
                                                                     methods: review.methods, other: review.other } %>

--- a/stash_datacite/app/views/stash_datacite/resources/_show_pdf.html.erb
+++ b/stash_datacite/app/views/stash_datacite/resources/_show_pdf.html.erb
@@ -11,7 +11,7 @@
                        version: @resource.stash_version.nil? ? 'v0' : "v#{@review.version.version }",
                        identifier: @resource.identifier.nil? ? 'DOI' : "#{@review.identifier.identifier }",
                        publisher: "#{@review.publisher}",
-                       publication_years: @resource.publication_years }
+                       publication_year: (@resource.publication_date.present? ? @resource.publication_date.year : @resource.updated_at.year) }
   %>
 </section>
 <%= render partial: "stash_datacite/descriptions/show", locals: { abstract: @review.abstract,

--- a/stash_datacite/app/views/stash_datacite/shared/_citations.html.erb
+++ b/stash_datacite/app/views/stash_datacite/shared/_citations.html.erb
@@ -1,2 +1,2 @@
 <h3 class="o-heading__level2">Citation</h3>
-<p><%= citation(authors, title, resource_type, version, identifier, publisher, publication_years) %></p>
+<p><%= citation(authors, title, resource_type, version, identifier, publisher, publication_year) %></p>

--- a/stash_engine/app/views/stash_engine/landing/_files.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_files.html.erb
@@ -7,7 +7,7 @@
     <% resources.each do |res| %>
       <details class="c-file-group" role="group">
         <summary class="o-showhide__summary c-file-group__summary">
-          <%= formatted_date(res.updated_at) %></summary>
+          <%= formatted_date(res.publication_date.present? ? res.publication_date : res.updated_at) %></summary>
         <ul class="c-file-group__list">
           <% res.current_file_uploads.each do |fu| %>
             <li>


### PR DESCRIPTION
Code was using `resource.updated_at` so updated to instead use `resource.publication_date`. The code defaults to the old `updated_at` if there is no `publication_date` defined to allow the page to continue to display in the event that there's an issue