### PR TITLE
Fix fee waiver bug

### DIFF
--- a/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -19,12 +19,17 @@ module StashDatacite
       (short_name.blank? ? long_name.strip : short_name.strip)
     end
 
-    def fee_waivered?
-      return false if ror_id.blank?
-      # Retrieve the ROR record and then check if itys a fee waiver country
+    def country_name
+      return nil if ror_id.blank?
       ror_org = find_by_ror_id(ror_id)
-      return false unless ror_org.present? && ror_org.country.present? && ror_org.country[:name].present?
-      fee_waiver_countries&.include?(ror_org.country[:name])
+      return nil if ror_org.nil? || ror_org.country.nil?
+      ror_org.country["country_name"]
+    end
+    
+    def fee_waivered?
+      return false if country_name.nil?
+      return false unless country_name.present?
+      fee_waiver_countries&.include?(country_name)
     end
 
     def fee_waiver_countries

--- a/stash_datacite/app/models/stash_datacite/affiliation.rb
+++ b/stash_datacite/app/models/stash_datacite/affiliation.rb
@@ -23,9 +23,9 @@ module StashDatacite
       return nil if ror_id.blank?
       ror_org = find_by_ror_id(ror_id)
       return nil if ror_org.nil? || ror_org.country.nil?
-      ror_org.country["country_name"]
+      ror_org.country['country_name']
     end
-    
+
     def fee_waivered?
       return false if country_name.nil?
       return false unless country_name.present?

--- a/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -1,3 +1,4 @@
+
 <div>
   <h3>License and Terms of Service</h3>
   <p>
@@ -42,7 +43,7 @@
 <% elsif submitter_affiliation.present? && submitter_affiliation.fee_waivered? %>
 <div>
   <h3>Payment</h3>
-  <p>Payment is not required for this deposit due to association with <b><%= submitter_affiliation.name %></b> in <b><%= submitter_affiliation.country %></b>.</p>
+   <p>Payment is not required for this deposit due to association with <b><%= submitter_affiliation.smart_name %></b> in <b><%= submitter_affiliation.country_name %></b>.</p>
 </div>
 <% elsif @resource.identifier.user_must_pay? %>
 <div>
@@ -87,3 +88,4 @@ $(document).ready(function(){
     $('#agree_to_license, #agree_to_dda').prop('disabled', true);
   </script>
 <% end %>
+

--- a/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
+++ b/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
@@ -54,5 +54,17 @@ module StashDatacite
         expect(@affil.fee_waivered?).to eql(true)
       end
     end
+
+    describe :country_name do
+      before(:each) do
+        @affil = StashDatacite::Affiliation.create(long_name: 'Bertelsmann Music Group', ror_id: '12345')
+        @ror_org = Stash::Organization::Ror::Organization.new(id: '12345', name: 'Bertelsmann Music Group')
+        allow_any_instance_of(Stash::Organization::Ror).to receive(:find_by_ror_id).and_return(@ror_org)
+      end
+      it 'returns the correct country_name when given a country object' do
+        @ror_org.country = { 'country_code' => 'TL', 'country_name' => 'East Timor' }
+        expect(@affil.country_name).to eql('East Timor')
+      end
+    end
   end
 end

--- a/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
+++ b/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
@@ -46,11 +46,11 @@ module StashDatacite
         expect(@affil.fee_waivered?).to eql(false)
       end
       it 'returns false if the associated ROR record\'s country is NOT in the fee waiver list' do
-        @ror_org.country = { name: 'Nowhereland' }
+        @ror_org.country = {"country_code"=>"NoW", "country_name"=>"Nowhereland"} 
         expect(@affil.fee_waivered?).to eql(false)
       end
       it 'returns true if the associated ROR record\'s country is in the fee waiver list' do
-        @ror_org.country = { name: 'East Timor' }
+        @ror_org.country = {"country_code"=>"TL", "country_name"=>"East Timor"}
         expect(@affil.fee_waivered?).to eql(true)
       end
     end

--- a/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
+++ b/stash_datacite/spec/db/stash_datacite/affiliation_spec.rb
@@ -46,11 +46,11 @@ module StashDatacite
         expect(@affil.fee_waivered?).to eql(false)
       end
       it 'returns false if the associated ROR record\'s country is NOT in the fee waiver list' do
-        @ror_org.country = {"country_code"=>"NoW", "country_name"=>"Nowhereland"} 
+        @ror_org.country = { 'country_code' => 'NoW', 'country_name' => 'Nowhereland' }
         expect(@affil.fee_waivered?).to eql(false)
       end
       it 'returns true if the associated ROR record\'s country is in the fee waiver list' do
-        @ror_org.country = {"country_code"=>"TL", "country_name"=>"East Timor"}
+        @ror_org.country = { 'country_code' => 'TL', 'country_name' => 'East Timor' }
         expect(@affil.fee_waivered?).to eql(true)
       end
     end

--- a/stash_engine/lib/stash/organization/ror.rb
+++ b/stash_engine/lib/stash/organization/ror.rb
@@ -58,7 +58,7 @@ module Stash
         def initialize(params)
           @id = params['id']
           @name = params['name']
-          @country = params['country'] || { 'code': nil, 'name': nil }
+          @country = params['country'] || { 'country_code': nil, 'country_name': nil }
           @acronyms = params['acronyms'] || []
         end
 


### PR DESCRIPTION
Fixes the issue with fee waivers not working (https://github.com/CDL-Dryad/dryad-product-roadmap/issues/291). The primary issue was a difference between `country[:name]` (previously used in the code and tests) and `country['country_name']` (the actual structure returned by ROR).

Fixes the secondary display issue on the review page by surfacing the `affiliation.country_name`. (And this also simplifies the logic for `fee_waivered?`)