### PR TITLE
added journal facet to solr

### DIFF
--- a/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -84,7 +84,8 @@ module Stash
           dct_issued_dt: issued_date,
           dc_rights_s: license_name,
           dc_publisher_s: publisher,
-          dct_temporal_sm: dct_temporal_dates
+          dct_temporal_sm: dct_temporal_dates,
+          dryad_related_publication_name_s: related_publication_name
         }
       end
       # rubocop:enable
@@ -208,6 +209,10 @@ module Stash
 
       def bounding_box_envelope
         (bbox = calc_bounding_box) ? bbox.to_envelope : nil
+      end
+
+      def related_publication_name
+        @resource.identifier.internal_data.where(data_type: 'publicationName').first&.value
       end
 
       private

--- a/stash_datacite/spec/factories.rb
+++ b/stash_datacite/spec/factories.rb
@@ -119,4 +119,9 @@ FactoryBot.define do
     subject { 'freshwater cats' }
     resources { [create(:resource)] }
   end
+
+  factory(:internal_data, class: StashEngine::InternalDatum) do
+    data_type { 'publicationName' }
+    value { 'Journal of Testing Fun' }
+  end
 end

--- a/stash_datacite/spec/unit/stash/indexer/indexing_resource_spec.rb
+++ b/stash_datacite/spec/unit/stash/indexer/indexing_resource_spec.rb
@@ -51,6 +51,7 @@ module Stash
       before :each do
         @user = create(:user)
         @identifier = create(:identifier)
+        @internal_data = create(:internal_data, identifier_id: @identifier.id)
         @resource = create(:resource, identifier_id: @identifier.id, user_id: @user.id)
         @resource_state = create(:resource_state, resource_id: @resource.id)
         @resource.update(current_resource_state_id: @resource_state.id)
@@ -281,7 +282,8 @@ module Stash
             dct_issued_dt: '2008-09-15T15:53:00Z',
             dc_rights_s: 'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
             dc_publisher_s: 'Dryad',
-            dct_temporal_sm: ['2018-11-14']
+            dct_temporal_sm: ['2018-11-14'],
+            dryad_related_publication_name_s: 'Journal of Testing Fun'
           }
           expect(mega_hash).to eql(expected_mega_hash)
         end

--- a/stash_discovery/app/controllers/catalog_controller.rb
+++ b/stash_discovery/app/controllers/catalog_controller.rb
@@ -86,6 +86,7 @@ class CatalogController < ApplicationController
     config.add_facet_field Settings.FIELDS.SUBJECT, label: 'Subject Area', limit: 8
     config.add_facet_field Settings.FIELDS.SPATIAL_COVERAGE, label: 'Geographical Location', limit: 8
     config.add_facet_field Settings.FIELDS.PART_OF, label: 'Collection', limit: 8
+    config.add_facet_field Settings.FIELDS.RELATED_PUBLICATION_NAME, label: 'Journal', limit: 8
 
     # config.add_facet_field Settings.FIELDS.RIGHTS, label: 'Access', limit: 8, partial: "icon_facet"
     # config.add_facet_field Settings.FIELDS.GEOM_TYPE, label: 'Data type', limit: 8, partial: "icon_facet"
@@ -116,6 +117,7 @@ class CatalogController < ApplicationController
     config.add_index_field Settings.FIELDS.CREATOR
     config.add_index_field Settings.FIELDS.DESCRIPTION, helper_method: :snippit
     config.add_index_field Settings.FIELDS.PUBLISHER
+    config.add_index_field Settings.FIELDS.RELATED_PUBLICATION_NAME
 
     # solr fields to be displayed in the show (single result) view
     #  The ordering of the field names is the order of the display
@@ -131,6 +133,7 @@ class CatalogController < ApplicationController
     config.add_show_field Settings.FIELDS.SUBJECT, label: 'Subject Area(s)', itemprop: 'keywords', link_to_search: true
     config.add_show_field Settings.FIELDS.TEMPORAL, label: 'Year', itemprop: 'temporal'
     config.add_show_field Settings.FIELDS.PROVENANCE, label: 'Held by', link_to_search: true
+    config.add_show_field Settings.FIELDS.RELATED_PUBLICATION_NAME, label: 'Journal', itemprop: 'related_publication_name'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/stash_discovery/app/controllers/latest_controller.rb
+++ b/stash_discovery/app/controllers/latest_controller.rb
@@ -59,6 +59,7 @@ class LatestController < ApplicationController
     config.add_show_field 'dc_subject_sm', label: 'Subject Area(s)', itemprop: 'keywords', link_to_search: true
     config.add_show_field 'dct_temporal_sm', label: 'Year', itemprop: 'temporal'
     config.add_show_field 'dct_provenance_s', label: 'Held by', link_to_search: true
+    config.add_show_field 'dryad_related_publication_name_s', label: 'Journal', itemprop: 'related_publication_name'
 
   end
 

--- a/stash_discovery/app/views/catalog/_home_text.html.erb
+++ b/stash_discovery/app/views/catalog/_home_text.html.erb
@@ -27,6 +27,13 @@
         <h4>Subject</h4>
         <%= render_facet_tags [Settings.FIELDS.SUBJECT] %>
       </div>
+      <div class='category-block'>
+        <div class='category-icon'>
+          <span><i class="fa fa-book" aria-hidden="true" style="color: steelblue;size: 100px;"></i></span>
+        </div>
+        <h4>Journal</h4>
+        <%= render_facet_tags [Settings.FIELDS.RELATED_PUBLICATION_NAME] %>
+      </div>
     </div>
     <div class='col-md-6 text-center'>
       <%= content_tag :h3, t('geoblacklight.home.map_heading') %>

--- a/stash_discovery/lib/tasks/rsolr.rake
+++ b/stash_discovery/lib/tasks/rsolr.rake
@@ -1,0 +1,13 @@
+namespace :rsolr do
+
+  desc 'Reindex the identifier/resource records in Geoblacklight'
+  task reindex: :environment do # loads rails environment
+    p 'Resubmitting Dataset information to Geoblacklight for datasets with published metadata.'
+    StashEngine::Identifier.includes(:internal_data, :latest_resource).all.each do |identifier|
+      next unless identifier.latest_resource.metadata_published?
+      identifier.latest_resource.submit_to_solr
+    end
+    p 'Complete'
+  end
+
+end


### PR DESCRIPTION
- Added `dryad_related_publication_name_s` to stash_datacite and stash_discovery.
- Added new `rsolr:reindex` rake task to resubmit datasets with the journal name.

@sfisher I updated the `schema.xml` and `solrconfig.xml` on the solr server in the `apps/solr/data/geoblacklight/conf` directory. I'm not sure where these files are managed

goes with the corresponding updates to dryad_config repo