### PR TITLE
Make both travis and local tests use dryad-config-example settings

### DIFF
--- a/stash_engine/config/initializers/licenses.rb
+++ b/stash_engine/config/initializers/licenses.rb
@@ -3,3 +3,5 @@ require 'ostruct'
 lic = File.join(Rails.application.root, 'config', 'licenses.yml')
 raise "License configuration file #{lic} not found" unless File.exist?(lic)
 LICENSES = YAML.load_file(lic).with_indifferent_access
+# the license stuff for example config is too much of a tangle to fix right now
+# LICENSES = YAML.load(ERB.new(File.read(lic)).result)[Rails.env]

--- a/stash_engine/config/initializers/licenses.rb
+++ b/stash_engine/config/initializers/licenses.rb
@@ -1,6 +1,11 @@
 require 'yaml'
 require 'ostruct'
-lic = File.join(Rails.application.root, 'config', 'licenses.yml')
+example_lic = File.join(Rails.application.root, 'dryad-config-example', 'licenses.yml')
+if Rails.env == 'test' && File.exist?(example_lic)
+  lic = example_lic
+else
+  lic = File.join(Rails.application.root, 'config', 'licenses.yml')
+end
 raise "License configuration file #{lic} not found" unless File.exist?(lic)
 LICENSES = YAML.load_file(lic).with_indifferent_access
 # the license stuff for example config is too much of a tangle to fix right now


### PR DESCRIPTION
See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/287 for an explanation of this problem.

This merges across **all 3 repos.**  I've added a test for the method that loads the dynamically inserted test environment information into yml files.  I couldn't get database.yml to substitute, but I think I got most of the rest and I'm not sure the database.yml is so much of a problem.