### PR TITLE
Fixed some issues with url translators

### DIFF
--- a/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash_engine/app/models/stash_engine/url_validator.rb
@@ -45,11 +45,6 @@ module StashEngine
         @timed_out = false
         response = client.head(@url, follow_redirect: true)
         init_from(response)
-
-p @url
-p "WTF? #{status_code} :: #{response.headers.inspect}"
-
-
         # the follow is for google drive which doesn't respond to head requests correctly
         fix_by_get_request(redirected_to || url) if status_code == 503
         return true
@@ -198,18 +193,9 @@ p "WTF? #{status_code} :: #{response.headers.inspect}"
     end
 
     def get_without_download(url, limit = 5)
-
-p "LIMIT: #{limit} --> #{url}"
-
-      raise 'Too many HTTP redirects' if limit <= 0
-      # this is supposed to NOT download the whole file
-      response = Net::HTTP.start(url.host, url.port, use_ssl: (url.scheme == 'https')) do |conn|
-        #conn.request_get(url) { |response| return response }
-        conn.request_get(url)
+      Net::HTTP.start(url.host, url.port, use_ssl: (url.scheme == 'https')) do |conn|
+        conn.request_get(url) { |response| return response }
       end
-      # try the new location if we got a redirect
-      response = get_without_download(response['location'], limit - 1) if response.is_a?(Net::HTTPRedirection)
-      response
     end
 
   end

--- a/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash_engine/app/models/stash_engine/url_validator.rb
@@ -192,7 +192,7 @@ module StashEngine
       @filename = filename_from(response, u, u)
     end
 
-    def get_without_download(url, limit = 5)
+    def get_without_download(url)
       Net::HTTP.start(url.host, url.port, use_ssl: (url.scheme == 'https')) do |conn|
         conn.request_get(url) { |response| return response }
       end

--- a/stash_engine/lib/stash/url_translator.rb
+++ b/stash_engine/lib/stash/url_translator.rb
@@ -3,7 +3,8 @@ module Stash
     # a class to translate URLs to direct download links for cloud services.
 
     # test links
-    # google_drive: https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing
+    # google_drive_file: https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing
+    # google_drive_open: https://drive.google.com/open?id=1P2lVY_NvGipGLYamQcxWcYe4mABha-3w
     # google_doc: https://docs.google.com/document/d/1vrQrKYAWVS9PeQHhOy9mcvDTvhgq85KCndScfrERHBk/edit?usp=sharing
     # google_presentation: https://docs.google.com/presentation/d/1w_S-nfMOnIUob_QqkWkQ-FrbUdQm0tr6X-CqvqOu-yc/edit?usp=sharing
     # google_sheet: https://docs.google.com/spreadsheets/d/1wUMpgSivZyCxqHMpnlJ5uvNcgQY8XvH1_3WBH7kvXjE/edit?usp=sharing
@@ -11,7 +12,8 @@ module Stash
     # box: https://ucop.box.com/s/o39s94g28puss5ttt7vss8b0qrlge184
     # non-mapped: http://www.koalastothemax.com/
 
-    GOOGLE_DRIVE = %r{^https://drive\.google\.com/file/d/(\S+)/(?:view|edit)(?:\?usp=sharing)?$}
+    GOOGLE_DRIVE_FILE = %r{^https://drive\.google\.com/file/d/(\S+)/(?:view|edit)(?:\?usp=sharing)?$}
+    GOOGLE_DRIVE_OPEN = %r{^https://drive\.google\.com/open\?id=(\S+)$}
     GOOGLE_DOC = %r{^https://docs\.google\.com/document/d/(\S+)/edit(?:\?usp=sharing)?$}
     GOOGLE_PRESENTATION = %r{^https://docs\.google\.com/presentation/d/(\S+)/edit(?:\?usp=sharing)?$}
     GOOGLE_SHEET = %r{^https://docs\.google\.com/spreadsheets/d/(\S+)/edit(?:\?usp=sharing)?$}
@@ -25,7 +27,7 @@ module Stash
       @original_url = (u.fragment ? original_url[0..-(u.fragment.length + 2)] : original_url)
       @service = nil
 
-      %w[google_drive google_doc google_presentation google_sheet dropbox box].each do |m|
+      %w[google_drive_file google_drive_open google_doc google_presentation google_sheet dropbox box].each do |m|
         next unless (@direct_download = send(m))
         @service = m
         @service = 'google' if m.start_with?('google')
@@ -36,9 +38,15 @@ module Stash
     private
 
     # these returns are supposed to be assignment, and not equality (==) because I want to check and assign at once
-    def google_drive
-      return nil unless (m = GOOGLE_DRIVE.match(@original_url))
-      "https://drive.google.com/uc?export=download&id=#{m[1]}"
+    def google_drive_file
+      return nil unless (m = GOOGLE_DRIVE_FILE.match(@original_url))
+      # "https://drive.google.com/uc?export=download&id=#{m[1]}"
+      @original_url
+    end
+
+    def google_drive_open
+      return nil unless (m = GOOGLE_DRIVE_OPEN.match(@original_url))
+      @original_url
     end
 
     def google_doc
@@ -63,7 +71,7 @@ module Stash
 
     def box
       return nil unless (m = BOX.match(@original_url))
-      "https://#{m[1]}/shared/static/#{m[2]}"
+      "https://#{m[1]}/public/static/#{m[2]}"
     end
 
   end

--- a/stash_engine/lib/stash/url_translator.rb
+++ b/stash_engine/lib/stash/url_translator.rb
@@ -39,13 +39,13 @@ module Stash
 
     # these returns are supposed to be assignment, and not equality (==) because I want to check and assign at once
     def google_drive_file
-      return nil unless (m = GOOGLE_DRIVE_FILE.match(@original_url))
+      return nil unless (GOOGLE_DRIVE_FILE.match(@original_url))
       # "https://drive.google.com/uc?export=download&id=#{m[1]}"
       @original_url
     end
 
     def google_drive_open
-      return nil unless (m = GOOGLE_DRIVE_OPEN.match(@original_url))
+      return nil unless (GOOGLE_DRIVE_OPEN.match(@original_url))
       @original_url
     end
 

--- a/stash_engine/lib/stash/url_translator.rb
+++ b/stash_engine/lib/stash/url_translator.rb
@@ -39,13 +39,13 @@ module Stash
 
     # these returns are supposed to be assignment, and not equality (==) because I want to check and assign at once
     def google_drive_file
-      return nil unless (GOOGLE_DRIVE_FILE.match(@original_url))
+      return nil unless GOOGLE_DRIVE_FILE.match(@original_url)
       # "https://drive.google.com/uc?export=download&id=#{m[1]}"
       @original_url
     end
 
     def google_drive_open
-      return nil unless (GOOGLE_DRIVE_OPEN.match(@original_url))
+      return nil unless GOOGLE_DRIVE_OPEN.match(@original_url)
       @original_url
     end
 

--- a/stash_engine/spec/unit/stash/url_translator_spec.rb
+++ b/stash_engine/spec/unit/stash/url_translator_spec.rb
@@ -5,7 +5,7 @@ module Stash
 
   describe :initialization do
 
-    it "sets the original_url" do
+    it 'sets the original_url' do
       translator = Stash::UrlTranslator.new('http://testing.example.org')
       expect(translator.original_url.present?).to eql(true)
     end

--- a/stash_engine/spec/unit/stash/url_translator_spec.rb
+++ b/stash_engine/spec/unit/stash/url_translator_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require_relative '../../../lib/stash/url_translator'
+
+module Stash
+
+  describe :initialization do
+
+    it "sets the original_url" do
+      translator = Stash::UrlTranslator.new('http://testing.example.org')
+      expect(translator.original_url.present?).to eql(true)
+    end
+
+    it 'attributes are correct for Google Drive `/file/d/` URLs' do
+      translator = Stash::UrlTranslator.new('https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing')
+      expect(translator.service).to eql('google')
+      expect(translator.direct_download).to eql('https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing')
+    end
+
+    it 'attributes are correct for Google Drive `/open?id=` URLs' do
+      translator = Stash::UrlTranslator.new('https://drive.google.com/open?id=1P2lVY_NvGipGLYamQcxWcYe4mABha-3w')
+      expect(translator.service).to eql('google')
+      expect(translator.direct_download).to eql('https://drive.google.com/open?id=1P2lVY_NvGipGLYamQcxWcYe4mABha-3w')
+    end
+
+    it 'sets the service to "google" for Google Docs URLs' do
+      translator = Stash::UrlTranslator.new('https://docs.google.com/document/d/1vrQrKYAWVS9PeQHhOy9mcvDTvhgq85KCndScfrERHBk/edit?usp=sharing')
+      expect(translator.service).to eql('google')
+      expect(translator.direct_download).to eql('https://docs.google.com/document/d/1vrQrKYAWVS9PeQHhOy9mcvDTvhgq85KCndScfrERHBk/export?format=doc')
+    end
+
+    it 'sets the service to "google" for Google Presentations URLs' do
+      translator = Stash::UrlTranslator.new('https://docs.google.com/presentation/d/1w_S-nfMOnIUob_QqkWkQ-FrbUdQm0tr6X-CqvqOu-yc/edit?usp=sharing')
+      expect(translator.service).to eql('google')
+      expect(translator.direct_download).to eql('https://docs.google.com/presentation/d/1w_S-nfMOnIUob_QqkWkQ-FrbUdQm0tr6X-CqvqOu-yc/export/pptx')
+    end
+
+    it 'sets the service to "google" for Google Sheets URLs' do
+      translator = Stash::UrlTranslator.new('https://docs.google.com/spreadsheets/d/1wUMpgSivZyCxqHMpnlJ5uvNcgQY8XvH1_3WBH7kvXjE/edit?usp=sharing')
+      expect(translator.service).to eql('google')
+      expect(translator.direct_download).to eql('https://docs.google.com/spreadsheets/d/1wUMpgSivZyCxqHMpnlJ5uvNcgQY8XvH1_3WBH7kvXjE/export?format=xlsx')
+    end
+
+    it 'sets the service to "dropbox" for Dropbox URLs' do
+      translator = Stash::UrlTranslator.new('https://www.dropbox.com/s/j84vdgcht1rxygb/generic_logo.svg?dl=0')
+      expect(translator.service).to eql('dropbox')
+      expect(translator.direct_download).to eql('https://dl.dropboxusercontent.com/s/j84vdgcht1rxygb/generic_logo.svg')
+    end
+
+    it 'sets the service to "box" for Box URLs' do
+      translator = Stash::UrlTranslator.new('https://ucop.box.com/s/o39s94g28puss5ttt7vss8b0qrlge184')
+      expect(translator.service).to eql('box')
+      expect(translator.direct_download).to eql('https://ucop.box.com/public/static/o39s94g28puss5ttt7vss8b0qrlge184')
+    end
+
+  end
+
+end


### PR DESCRIPTION
For issue: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/279

- Stopped transforming Google drive share links (still need to translate for Docs, Sheets and Presentations) ... @sfisher I'm not certain if this will work in all situations
- Updated download URL format for Box