### PR TITLE
Journal backfill for DB and Solr

### DIFF
--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -136,6 +136,9 @@ namespace :identifiers do
         end
       end
       StashEngine::InternalDatum.create(identifier_id: datum.identifier_id, data_type: 'publicationName', value: title) unless title.blank?
+      # Submit the info to Solr
+      identifier = StashEngine::Identifier.where(id: datum.identifier_id)
+      identifier.latest_resource.submit_to_solr if identifier.present? && identifier.latest_resource.present?
     end
     p "Finished: #{Time.now}"
   end

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -136,9 +136,12 @@ namespace :identifiers do
         end
       end
       StashEngine::InternalDatum.create(identifier_id: datum.identifier_id, data_type: 'publicationName', value: title) unless title.blank?
-      # Submit the info to Solr
+      # Submit the info to Solr if published/embargoed
       identifier = StashEngine::Identifier.where(id: datum.identifier_id)
-      identifier.latest_resource.submit_to_solr if identifier.present? && identifier.latest_resource.present?
+      if identifier.present? && identifier.latest_resource.present?
+        current_ca = identifier.latest_resource.current_curation_activity
+        identifier.latest_resource.submit_to_solr if current_ca.present? && (current_ca.published? || current_ca.embargoed?)
+      end
     end
     p "Finished: #{Time.now}"
   end

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -137,7 +137,7 @@ namespace :identifiers do
       end
       StashEngine::InternalDatum.create(identifier_id: datum.identifier_id, data_type: 'publicationName', value: title) unless title.blank?
       # Submit the info to Solr if published/embargoed
-      identifier = StashEngine::Identifier.where(id: datum.identifier_id)
+      identifier = StashEngine::Identifier.where(id: datum.identifier_id).first
       if identifier.present? && identifier.latest_resource.present?
         current_ca = identifier.latest_resource.current_curation_activity
         identifier.latest_resource.submit_to_solr if current_ca.present? && (current_ca.published? || current_ca.embargoed?)

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -139,8 +139,8 @@ namespace :identifiers do
       # Submit the info to Solr if published/embargoed
       identifier = StashEngine::Identifier.where(id: datum.identifier_id).first
       if identifier.present? && identifier.latest_resource.present?
-        current_ca = identifier.latest_resource.current_curation_activity
-        identifier.latest_resource.submit_to_solr if current_ca.present? && (current_ca.published? || current_ca.embargoed?)
+        current_resource = identifier.latest_resource_with_public_metadata
+        current_resource.submit_to_solr if current_resource.present?
       end
     end
     p "Finished: #{Time.now}"


### PR DESCRIPTION
Update rake task to submit the records to Solr after updating their publication name.

@ryscher it doesn't look like the journal names were added to the migrated datasets. This PR contains a rake task that can be used to backfill that information (will do a Crossref API lookup for any publicationISSNs without a corresponding publicationName).

Alternatively you can also add an additional API call to your process to add it manually if you are already able to get it from the old system. I'm not super familiar with the API but it looks like this would work: `# post /datasets/<id>/set_internal_datum` with `{ data_type: 'publicationName', value: 'Some journal' }`
