### PR TITLE
Revert google url translators

### DIFF
--- a/stash_engine/app/models/stash_engine/url_validator.rb
+++ b/stash_engine/app/models/stash_engine/url_validator.rb
@@ -46,7 +46,7 @@ module StashEngine
         response = client.head(@url, follow_redirect: true)
         init_from(response)
         # the follow is for google drive which doesn't respond to head requests correctly
-        fix_by_get_request(redirected_to || url) if status_code == 503
+        fix_by_get_request(redirected_to || url) if google_drive_redirect?(status_code, redirected_to)
         return true
       rescue HTTPClient::TimeoutError
         @timed_out = true
@@ -196,6 +196,10 @@ module StashEngine
       Net::HTTP.start(url.host, url.port, use_ssl: (url.scheme == 'https')) do |conn|
         conn.request_get(url) { |response| return response }
       end
+    end
+
+    def google_drive_redirect?(status_code, redirected_to)
+      status_code >= 500 && redirected_to.include?('googleusercontent.com')
     end
 
   end

--- a/stash_engine/lib/stash/url_translator.rb
+++ b/stash_engine/lib/stash/url_translator.rb
@@ -3,8 +3,7 @@ module Stash
     # a class to translate URLs to direct download links for cloud services.
 
     # test links
-    # google_drive_file: https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing
-    # google_drive_open: https://drive.google.com/open?id=1P2lVY_NvGipGLYamQcxWcYe4mABha-3w
+    # google_drive: https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing
     # google_doc: https://docs.google.com/document/d/1vrQrKYAWVS9PeQHhOy9mcvDTvhgq85KCndScfrERHBk/edit?usp=sharing
     # google_presentation: https://docs.google.com/presentation/d/1w_S-nfMOnIUob_QqkWkQ-FrbUdQm0tr6X-CqvqOu-yc/edit?usp=sharing
     # google_sheet: https://docs.google.com/spreadsheets/d/1wUMpgSivZyCxqHMpnlJ5uvNcgQY8XvH1_3WBH7kvXjE/edit?usp=sharing
@@ -12,8 +11,7 @@ module Stash
     # box: https://ucop.box.com/s/o39s94g28puss5ttt7vss8b0qrlge184
     # non-mapped: http://www.koalastothemax.com/
 
-    GOOGLE_DRIVE_FILE = %r{^https://drive\.google\.com/file/d/(\S+)/(?:view|edit)(?:\?usp=sharing)?$}
-    GOOGLE_DRIVE_OPEN = %r{^https://drive\.google\.com/open\?id=(\S+)$}
+    GOOGLE_DRIVE = %r{^https://drive\.google\.com/file/d/(\S+)/(?:view|edit)(?:\?usp=sharing)?$}
     GOOGLE_DOC = %r{^https://docs\.google\.com/document/d/(\S+)/edit(?:\?usp=sharing)?$}
     GOOGLE_PRESENTATION = %r{^https://docs\.google\.com/presentation/d/(\S+)/edit(?:\?usp=sharing)?$}
     GOOGLE_SHEET = %r{^https://docs\.google\.com/spreadsheets/d/(\S+)/edit(?:\?usp=sharing)?$}
@@ -27,7 +25,7 @@ module Stash
       @original_url = (u.fragment ? original_url[0..-(u.fragment.length + 2)] : original_url)
       @service = nil
 
-      %w[google_drive_file google_drive_open google_doc google_presentation google_sheet dropbox box].each do |m|
+      %w[google_drive google_doc google_presentation google_sheet dropbox box].each do |m|
         next unless (@direct_download = send(m))
         @service = m
         @service = 'google' if m.start_with?('google')
@@ -38,15 +36,9 @@ module Stash
     private
 
     # these returns are supposed to be assignment, and not equality (==) because I want to check and assign at once
-    def google_drive_file
-      return nil unless GOOGLE_DRIVE_FILE.match(@original_url)
-      # "https://drive.google.com/uc?export=download&id=#{m[1]}"
-      @original_url
-    end
-
-    def google_drive_open
-      return nil unless GOOGLE_DRIVE_OPEN.match(@original_url)
-      @original_url
+    def google_drive
+      return nil unless (m = GOOGLE_DRIVE.match(@original_url))
+      "https://drive.google.com/uc?export=download&id=#{m[1]}"
     end
 
     def google_doc

--- a/stash_engine/spec/unit/stash/url_translator_spec.rb
+++ b/stash_engine/spec/unit/stash/url_translator_spec.rb
@@ -10,16 +10,10 @@ module Stash
       expect(translator.original_url.present?).to eql(true)
     end
 
-    it 'attributes are correct for Google Drive `/file/d/` URLs' do
+    it 'attributes are correct for Google Drive URLs' do
       translator = Stash::UrlTranslator.new('https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing')
       expect(translator.service).to eql('google')
-      expect(translator.direct_download).to eql('https://drive.google.com/file/d/0B9diV3DhsADzQ2Q2aDZGRFlkLVU/view?usp=sharing')
-    end
-
-    it 'attributes are correct for Google Drive `/open?id=` URLs' do
-      translator = Stash::UrlTranslator.new('https://drive.google.com/open?id=1P2lVY_NvGipGLYamQcxWcYe4mABha-3w')
-      expect(translator.service).to eql('google')
-      expect(translator.direct_download).to eql('https://drive.google.com/open?id=1P2lVY_NvGipGLYamQcxWcYe4mABha-3w')
+      expect(translator.direct_download).to eql('https://drive.google.com/uc?export=download&id=0B9diV3DhsADzQ2Q2aDZGRFlkLVU')
     end
 
     it 'sets the service to "google" for Google Docs URLs' do


### PR DESCRIPTION
reverted recent change to google url_translator that was accepting the html viewer version of google drive documents.

Updated url_validator to fix issue with google drive returning an HTTP 500 instead of 503. Will now attempt to follow the redirection for any HTTP status >= 500 with a redirect Location of for 'googleusercontent.com'

updated tests