### PR TITLE
Updated resource.curatable to allow embargoed to have status changes

### DIFF
--- a/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
+++ b/stash_engine/app/helpers/stash_engine/admin_datasets_helper.rb
@@ -20,6 +20,8 @@ module StashEngine
         statuses = statuses.select { |s| %w[curation withdrawn].include?(s) }
       when 'withdrawn'
         statuses = statuses.select { |s| %w[curation].include?(s) }
+      when 'embargoed'
+        statuses = statuses.select { |s| %w[curation withdrawn published].include?(s) }
       else
         unavailable = %w[in_progress submitted peer_review]
         unavailable << current_status

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -324,7 +324,7 @@ module StashEngine
     # ------------------------------------------------------------
     # Curation helpers
     def curatable?
-      submitted? && !files_published?
+      (submitted? && !files_published?) || current_curation_activity.embargoed?
     end
 
     def current_curation_activity

--- a/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_curation_activity_form.html.erb
@@ -4,7 +4,7 @@
   <%= form_for :resource, url: curation_activity_change_path(resource.id), method: :post, remote: true do |f| %>
 
     <%# Users cannot change the status or publication date once the files are published %>
-    <% unless resource.files_published? %>
+    <% if resource.curatable? %>
       <%= f.fields_for :curation_activity, curation_activity do |ca| %>
         <div class="c-input">
           <label class="c-input__label">Status</label>


### PR DESCRIPTION
For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/305

Updated `resource.curatable?` logic to allow embargoed resources to have their status changed to 'curation', 'withdrawn' or 'published'

Do we need to think about other ramifications @sfisher? For example if something is embargoed and changed to withdrawn or curation do we need to pull it from Solr?