### PR TITLE
Fix for bug in curation_activity user (curator vs owner of the resource)

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -68,7 +68,7 @@ module StashEngine
       respond_to do |format|
         format.js do
           @resource = Resource.find(params[:id])
-          @resource.editor = current_user
+          @resource.current_editor_id = current_user.id
           decipher_curation_activity
           @resource.publication_date = @pub_date
           @resource.curation_activities << CurationActivity.create(user_id: current_user.id, status: @status,
@@ -122,7 +122,7 @@ module StashEngine
       ca_ids = Resource.latest_curation_activity_per_resource.collect { |i| i[:curation_activity_id] }
 
       resources = Resource.joins(:identifier, :authors, :current_resource_state, :curation_activities)
-        .includes(:authors, :current_resource_state, identifier: :internal_data, :curation_activities, :editor)
+        .includes(:authors, :current_resource_state, :curation_activities, :editor, identifier: :internal_data)
         .where(stash_engine_resources: { id: resource_ids })
         .where(stash_engine_curation_activities: { id: ca_ids })
 

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -68,6 +68,7 @@ module StashEngine
       respond_to do |format|
         format.js do
           @resource = Resource.find(params[:id])
+          @resource.editor = current_user
           decipher_curation_activity
           @resource.publication_date = @pub_date
           @resource.curation_activities << CurationActivity.create(user_id: current_user.id, status: @status,
@@ -108,7 +109,7 @@ module StashEngine
          sort_column_definition('author', 'stash_engine_authors', %w[author_last_name author_first_name]),
          sort_column_definition('doi', 'stash_engine_identifiers', %w[identifier]),
          sort_column_definition('last_modified', 'stash_engine_curation_activities', %w[updated_at]),
-         sort_column_definition('modified_by', 'stash_engine_users', %w[last_name first_name]),
+         sort_column_definition('editor', 'stash_engine_users', %w[last_name first_name]),
          sort_column_definition('size', 'stash_engine_identifiers', %w[storage_size]),
          sort_column_definition('publication_date', 'stash_engine_resources', %w[publication_date])]
       )
@@ -121,7 +122,7 @@ module StashEngine
       ca_ids = Resource.latest_curation_activity_per_resource.collect { |i| i[:curation_activity_id] }
 
       resources = Resource.joins(:identifier, :authors, :current_resource_state, :curation_activities)
-        .includes(:authors, :current_resource_state, identifier: :internal_data, curation_activities: :user)
+        .includes(:authors, :current_resource_state, identifier: :internal_data, :curation_activities, :editor)
         .where(stash_engine_resources: { id: resource_ids })
         .where(stash_engine_curation_activities: { id: ca_ids })
 

--- a/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/metadata_entry_pages_controller.rb
@@ -55,6 +55,8 @@ module StashEngine
     def duplicate_resource
       @new_res = @resource.amoeba_dup
       @new_res.current_editor_id = current_user.id
+      # The default curation activity gets set to the `Resource.user_id` but we want to use the current user here
+      @new_res.curation_activities.update_all(user_id: current_user.id)
       @new_res.save!
     end
 

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -338,7 +338,7 @@ module StashEngine
 
     # Create the initial CurationActivity
     def init_curation_status
-      curation_activities << StashEngine::CurationActivity.new(user_id: user_id)
+      curation_activities << StashEngine::CurationActivity.new(user_id: current_editor_id || user_id)
     end
     private :init_curation_status
 

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -338,7 +338,7 @@ module StashEngine
 
     # Create the initial CurationActivity
     def init_curation_status
-      curation_activities << StashEngine::CurationActivity.new(user: user)
+      curation_activities << StashEngine::CurationActivity.new(user_id: user_id)
     end
     private :init_curation_status
 

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -16,8 +16,8 @@
     <th class="c-admin-table <%= sort_display('last_modified', @sort_column) %>" colspan="2">
       <%= sort_by 'last_modified', title: 'Last Modified', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table <%= sort_display('modified_by', @sort_column) %>">
-      <%= sort_by 'modified_by', title: 'Last modified by', current_column: @sort_column %>
+    <th class="c-admin-table <%= sort_display('editor', @sort_column) %>">
+      <%= sort_by 'editor', title: 'Last modified by', current_column: @sort_column %>
     </th>
     <th class="c-admin-table <%= sort_display('size', @sort_column) %>">
       <%= sort_by 'size', title: 'Size', current_column: @sort_column %>
@@ -65,7 +65,7 @@
           </button>
         <% end %>
       </td>
-      <td id="js-curation-activity-user-<%= identifier.id %>"><%= resource.current_curation_activity.user&.name %></td>
+      <td id="js-curation-activity-user-<%= identifier.id %>"><%= resource.editor&.name %></td>
       <td><%= filesize(identifier.storage_size) %></td>
       <td class="c-admin" id="js-embargo-state-<%= identifier.id %>">
         <%= formatted_date(resource&.publication_date) %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -34,7 +34,7 @@
       <td class="c-admin-hide-border-right">
         <%= link_to resource.title, show_path(id: identifier.to_s, latest: true), target: :blank %>
       </td>
-      <td class="c-admin-hide-border-left">
+      <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= resource.id %>">
         <% if resource&.current_curation_activity.curation? || resource&.dataset_in_progress_editor&.id == current_user.id %>
           <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: resource.id } %>
         <% end %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_change.js.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/curation_activity_change.js.erb
@@ -1,3 +1,6 @@
+<% if @resource.current_curation_activity.curation? %>
+  $("#js-edit-dataset-button-column-<%= @resource.id %>").html("<%= escape_javascript(render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: @resource.id }) %>");
+<% end %>
 $("#js-curation-state-<%= @resource.identifier.id %>").html("<%= @resource.current_curation_activity.readable_status %>");
 $("#js-embargo-state-<%= @resource.identifier.id %>").html("<%= formatted_date(@resource.publication_date) %>");
 $("#js-curation-activity-date-<%= @resource.identifier.id %>").html("<%= formatted_datetime(@resource.current_curation_activity&.created_at) %>");


### PR DESCRIPTION
For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/306

- Updated the Resource model's init logic to use the `current_editor_id` instead of `user_id`
- Updated the Admin page to set the `current_editor_id` to the current_user when changing status
- Updated the Admin page 'Last modified by' column to use the `editor`
- Fixed an issue where changing the status to 'Curation' was not displaying the 'edit metadata' pencil icon