### PR TITLE
New scope to support LinkOut

### DIFF
--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -36,6 +36,13 @@ module StashEngine
       end
     end
 
+    scope :cited_by_pubmed, -> do
+      joins(:internal_data).
+        publicly_viewable.
+        where('stash_engine_internal_data.data_type = ? AND stash_engine_internal_data.value IS NOT NULL', 'pubmedID').
+        order(:identifier)
+    end
+
     # has_many :counter_citations, class_name: 'StashEngine::CounterCitation', dependent: :destroy
     # before_create :build_associations
 

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -37,10 +37,10 @@ module StashEngine
     end
 
     scope :cited_by_pubmed, -> do
-      joins(:internal_data).
-        publicly_viewable.
-        where('stash_engine_internal_data.data_type = ? AND stash_engine_internal_data.value IS NOT NULL', 'pubmedID').
-        order(:identifier)
+      joins(:internal_data)
+        .publicly_viewable
+        .where('stash_engine_internal_data.data_type = ? AND stash_engine_internal_data.value IS NOT NULL', 'pubmedID')
+        .order(:identifier)
     end
 
     # has_many :counter_citations, class_name: 'StashEngine::CounterCitation', dependent: :destroy


### PR DESCRIPTION
For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/314

Added a new scope to the Identifier model to return datasets that are either published/embargoed and have a pubmedID in their internal datum

Goes with corresponding PR in the dryad repo which contains XML.ERB files and a new Rake task file.