### PR TITLE
Api queue info

### DIFF
--- a/stash_api/app/controllers/stash_api/submission_queue_controller.rb
+++ b/stash_api/app/controllers/stash_api/submission_queue_controller.rb
@@ -1,0 +1,12 @@
+require_dependency 'stash_api/application_controller'
+require_dependency 'stash_api/datasets_controller'
+
+module StashApi
+  class SubmissionQueueController < ApplicationController
+    before_action :require_json_headers
+    before_action :doorkeeper_authorize!
+    before_action :require_api_user
+    before_action :require_curator # curators and superusers are conflated
+
+  end
+end

--- a/stash_api/app/controllers/stash_api/submission_queue_controller.rb
+++ b/stash_api/app/controllers/stash_api/submission_queue_controller.rb
@@ -8,5 +8,14 @@ module StashApi
     before_action :require_api_user
     before_action :require_curator # curators and superusers are conflated
 
+    # gets the length of items waiting to process ie, queued or held with rejected_shutting_down
+    def length
+      # by default we should calculate the length as rejected_shutting_down and enqueued
+      @queue_length = StashEngine::RepoQueueState.latest_per_resource.where(state: %w[enqueued rejected_shutting_down]).count
+      @executor = StashEngine.repository.executor
+      respond_to do |format|
+        format.json { render json: {queue_length: @queue_length, executor_queue_length: @executor.queue_length} }
+      end
+    end
   end
 end

--- a/stash_api/app/controllers/stash_api/submission_queue_controller.rb
+++ b/stash_api/app/controllers/stash_api/submission_queue_controller.rb
@@ -14,7 +14,7 @@ module StashApi
       @queue_length = StashEngine::RepoQueueState.latest_per_resource.where(state: %w[enqueued rejected_shutting_down]).count
       @executor = StashEngine.repository.executor
       respond_to do |format|
-        format.json { render json: {queue_length: @queue_length, executor_queue_length: @executor.queue_length} }
+        format.json { render json: { queue_length: @queue_length, executor_queue_length: @executor.queue_length } }
       end
     end
   end

--- a/stash_api/config/routes.rb
+++ b/stash_api/config/routes.rb
@@ -32,4 +32,6 @@ StashApi::Engine.routes.draw do
 
   resources :users, only: %i[index show]
 
+  get '/queue_length', to: 'submisisons_queue#length'
+
 end

--- a/stash_api/config/routes.rb
+++ b/stash_api/config/routes.rb
@@ -32,6 +32,6 @@ StashApi::Engine.routes.draw do
 
   resources :users, only: %i[index show]
 
-  get '/queue_length', to: 'submisisons_queue#length'
+  get '/queue_length', to: 'submission_queue#length'
 
 end


### PR DESCRIPTION
This PR involves one on both dryad and stash repositories (copying and pasting description into both).

This is for our migration so as not to overwhelm things.  You can make a call to /api/queue_length with all the usual API headers, etc.

It will allow monitoring of queue length so as not to keep sending more stuff to the server if it already has a lot in queue (or it is being held for shutdown).  It returns the `queue_length` & `executor_queue_length`.

Generally speaking the executor queue length is about double (or sometimes a little more) the things that are actually queued for work to be done since the success/error callbacks also get put on the executor queue separately by the internals of the gem.

I'd probably do something like this (in pseudocode) and tune it if it either creates too much or too little of a queue.  I think we want to have a work queue most of the time, but we don't want too long of one.  You also probably don't want to query the queue too often and just top up with new batches of submissions.

```
loop until done
  query_queue_length
  if queue_length > 40 or executor_queue_length > 80
    sleep 30
  else
    send 40 more datasets to be deposited
  end
end
```

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/316
