### PR TITLE
Change test for enqueued

### DIFF
--- a/stash-merritt/lib/stash/merritt/submission_job.rb
+++ b/stash-merritt/lib/stash/merritt/submission_job.rb
@@ -25,7 +25,7 @@ module Stash
           # Do not send to the repo again if it has already been sent. If we need to re-send we'll have to delete the statuses
           # and re-submit manually.  This should be an exceptional case that we send the same resource to Merritt more than once.
           latest_queue = StashEngine::RepoQueueState.latest(resource_id: @resource__id)
-          latest_queue.destroy if latest_queue.present? && latest_queue.state.enqueued?
+          latest_queue.destroy if latest_queue.present? && (latest_queue.state == 'enqueued')
         else
           Stash::Repo::Repository.update_repo_queue_state(resource_id: @resource_id, state: 'processing')
           do_submit!


### PR DESCRIPTION
I was re-processing an item that had originally received an error during Merritt processing. It received this new error:

NoMethodError: undefined method `enqueued?` for "enqueued"::String
/apps/dryad/apps/ui/releases/stash/stash-merritt/lib/stash/merritt/submission_job.rb:28:in `submit!`

This change should fix the issue.