### PR TITLE
Retain the original publication date

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -72,9 +72,9 @@ module StashApi
 
       case params[:curation_activity][:status]
       when 'published'
-        record_published_date(resource) unless resource.publication_date.present?
+        record_published_date(resource)
       when 'embargoed'
-        record_embargoed_date(resource) unless resource.publication_date.present?
+        record_embargoed_date(resource)
       end
 
       StashEngine::CurationActivity.create(resource_id: resource.id,
@@ -85,11 +85,13 @@ module StashApi
     end
 
     def record_published_date(resource)
+      return if resource.publication_date.present?
       publish_date = params[:curation_activity][:created_at] || Time.now
-      resource.update!(publication_date: publish_date) 
+      resource.update!(publication_date: publish_date)
     end
 
     def record_embargoed_date(resource)
+      return if resource.publication_date.present?
       embargo_date = (params[:curation_activity][:created_at]&.to_date || Date.today) + 1.year
       resource.update!(publication_date: embargo_date)
     end

--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -72,9 +72,9 @@ module StashApi
 
       case params[:curation_activity][:status]
       when 'published'
-        record_published_date(resource)
+        record_published_date(resource) unless resource.publication_date.present?
       when 'embargoed'
-        record_embargoed_date(resource)
+        record_embargoed_date(resource) unless resource.publication_date.present?
       end
 
       StashEngine::CurationActivity.create(resource_id: resource.id,
@@ -86,7 +86,7 @@ module StashApi
 
     def record_published_date(resource)
       publish_date = params[:curation_activity][:created_at] || Time.now
-      resource.update!(publication_date: publish_date)
+      resource.update!(publication_date: publish_date) 
     end
 
     def record_embargoed_date(resource)


### PR DESCRIPTION
Part of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/55

In the API, when adding a curation activity is of type 'published' or 'embargoed', do not overwrite an existing publication date. Once an item already has a publication date, it should not be changed by subsequent curation notes.

To test manually, use the API to create multiple curation activities of type 'published'. The date associated with the first-created curation activity should remain as the publication date of the resource.

(A request test is included in the dryad repo, https://github.com/CDL-Dryad/dryad/pull/105)