### PR TITLE
Use the method on the class, not the instance

### DIFF
--- a/stash_engine/app/controllers/stash_engine/landing_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/landing_controller.rb
@@ -112,7 +112,7 @@ module StashEngine
       StashEngine.repository.harvested(identifier: id, record_identifier: record_identifier)
 
       if StashEngine::RepoQueueState.where(resource_id: @resource_id, state: 'completed').count < 1
-        StashEngine.repository.update_repo_queue_state(resource_id: @resource.id, state: 'completed')
+        StashEngine.repository.class.update_repo_queue_state(resource_id: @resource.id, state: 'completed')
       end
 
       # success but no content, see RFC 5789 sec. 2.1


### PR DESCRIPTION
I think this only triggers in cases when the status gets delayed from our queue and the notification from Merritt comes in faster, so harder to test since it's based on timing.

This is the method at https://github.com/CDL-Dryad/stash/blob/master/stash_engine/lib/stash/repo/repository.rb around line 111.