### PR TITLE
Handle PublicationDate that is explicitly set in a curation activity

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -95,8 +95,13 @@ module StashApi
       # regardless of whether a publication date has been set otherwise.
       explicit_pub_date = params[:curation_activity][:note].match(/PublicationDate=(\d+-\d+-\d+)/)
       if explicit_pub_date
-        resource.update!(publication_date: explicit_pub_date[1].to_date)
-        return
+        begin
+          resource.update!(publication_date: explicit_pub_date[1].to_date)
+          return
+        rescue StandardError
+          # If the explicit publication date is invalid, ignore it and handle as it if is absent.
+          nil
+        end
       end
 
       return if resource.publication_date.present?

--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -91,6 +91,14 @@ module StashApi
     end
 
     def record_embargoed_date(resource)
+      # If the curation activity has an explicit publication date, use that,
+      # regardless of whether a publication date has been set otherwise.
+      explicit_pub_date = params[:curation_activity][:note].match(/PublicationDate=(\d+-\d+-\d+)/)
+      if explicit_pub_date
+        resource.update!(publication_date: explicit_pub_date[1].to_date)
+        return
+      end
+
       return if resource.publication_date.present?
       embargo_date = (params[:curation_activity][:created_at]&.to_date || Date.today) + 1.year
       resource.update!(publication_date: embargo_date)


### PR DESCRIPTION
For ticket https://github.com/CDL-Dryad/dryad-product-roadmap/issues/338

This is somewhat specialized functionality for migration, so I'm not adding new response tests. (There are already response tests that test the primary addition of curation activities.)

To test, submit a curation activity through the API with status `embargoed`, and include an explicit PublicationDate. The call should look something like this:

```curl --data "@/tmp/prov.json" -i -X POST https://dryad-dev.cdlib.org/api/datasets/doi%3A10.5061%2Fdryad.30cn0/curation_activity -H "Authorization: Bearer ab9e32b3c6b76cbc58a5c65fe113e9ca2ca6269770f45cbba753a5c457b79f53" -H "Content-Type: application/json" -o curlout.txt```

With a prov.json that looks like this:

```{"status":"embargoed","note":"Setting package-level embargo to reflect file-level embargo. Type=oneyear, PublicationDate=2021-06-13T21:10:13.081+0000","created_at":"2019-06-13T21:10:13.083+0000"}```
