### PR TITLE
Discovered a bug in the status dashboard. 

### DIFF
--- a/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -42,6 +42,7 @@ module StashEngine
       return unless dependency.present?
       @dependency = dependency
       @url = status_dashboard_url
+      @submission_error_emails = APP_CONFIG['submission_error_email'] || [@helpdesk_email]
       mail(to: @submission_error_emails, bcc: @bcc_emails,
            subject: "#{rails_env} dependency offline: #{dependency.name}")
     end

--- a/stash_engine/app/views/stash_engine/status_dashboard/show.html.erb
+++ b/stash_engine/app/views/stash_engine/status_dashboard/show.html.erb
@@ -1,7 +1,7 @@
 <main>
   <h1>External Dependency Statuses</h1>
 
-  <p>The following lists represent the current status of Dryad's external dependencies. A green icon indicates that the service is online and operational, red indicates that the service is offline and yellow indicates that the service is either having trouble or we cannot determine it's status. Clicking on a red or yellow icon will open a dialog with troubleshooting information.</p>
+  <p>The following lists represent the current status of Dryad's external dependencies. A green icon indicates that the service is online and operational, red indicates that the service is offline and orange indicates that we could not determine it's status. Clicking on a red or orange icon will open a dialog with troubleshooting information.</p>
   <p>For general troubleshooting information, please refer to the: <%= link_to 'Main Dryad Documentation', @main_documentation %></p>
 
   <p><strong>The following dependencies were last checked on: <em><%= @latest_check.to_s %></em></strong></p>


### PR DESCRIPTION
added the appropriate 'to' email address for dependency check failures
Also updated the text on the status_dashboard page from 'yellow' to 'orange' (orange was in our color palette)