### PR TITLE
Prevent null pointer exception when displaying curation activities

### DIFF
--- a/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/activity_log.html.erb
@@ -4,7 +4,7 @@
 <div>
   <div style="float: left;"><br/><%= @identifier.to_s %></div>
   <div style="float: right;">
-    <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.latest_resource.id }, method: :get, remote: true) do -%>
+    <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'note_popup', id: @identifier&.latest_resource&.id }, method: :get, remote: true) do -%>
       <button class="o-button__submit">Add Note</button>
     <% end %>
   </div>


### PR DESCRIPTION
Handle the rare case when someone is viewing the curation activities page, but the identifier's latest_resource has not yet been set.