### PR TITLE
Api security part 1

### DIFF
--- a/stash_api/app/controllers/stash_api/application_controller.rb
+++ b/stash_api/app/controllers/stash_api/application_controller.rb
@@ -66,6 +66,7 @@ module StashApi
     end
 
     def optional_api_user
+      @user = nil
       @user = doorkeeper_token.application.owner if doorkeeper_token
     end
 

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -22,7 +22,7 @@ module StashApi
 
     # get /datasets/<id>
     def show
-      ds = Dataset.new(identifier: @stash_identifier.to_s)
+      ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user)
       respond_to do |format|
         format.json { render json: ds.metadata }
         res = @stash_identifier.latest_viewable_resource(user: @user)

--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -51,7 +51,7 @@ module StashApi
       # and we are ready to support whatever we decide.
 
       # if a publicationISSN is specified, we want to make sure that we're only working those specified.
-      unless params.key?('publicationISSN').blank?
+      if params.key?('publicationISSN')
         # add these conditions to narrow to publicationISSN
         ds_query = ds_query
           .joins('INNER JOIN stash_engine_internal_data ON stash_engine_identifiers.id = stash_engine_internal_data.identifier_id')
@@ -59,7 +59,7 @@ module StashApi
       end
 
       # now, if a curationStatus is specified, narrow down the previous result more.
-      unless params.key?('curationStatus').blank?
+      if params.key?('curationStatus')
         ds_query = ds_query.with_visibility(states: params['curationStatus']) # this finds identifiers with a version with this state, acceptable?
       end
 

--- a/stash_api/app/controllers/stash_api/general_controller.rb
+++ b/stash_api/app/controllers/stash_api/general_controller.rb
@@ -9,7 +9,8 @@ module StashApi
     before_action :doorkeeper_authorize!, only: :test
     before_action :require_api_user, only: :test
 
-    # get /datasets
+    # get /
+    # All this really does is return the basic HATEOAS link to the base level dataset links
     def index
       respond_to do |format|
         format.json { render json: output }

--- a/stash_api/app/models/stash_api/dataset.rb
+++ b/stash_api/app/models/stash_api/dataset.rb
@@ -6,35 +6,25 @@ module StashApi
   class Dataset
     include StashApi::Presenter
 
-    def initialize(identifier:)
+    def initialize(identifier:, user: nil)
       id_type, iden = identifier.split(':', 2)
       @se_identifier = StashEngine::Identifier.where(identifier_type: id_type, identifier: iden).first
+      @user = user
+    end
+
+    def last_se_resource
+      @se_identifier.latest_viewable_resource(user: @user)
     end
 
     def last_version
-      return nil unless @se_identifier.resources.count.positive?
-      res_id = @se_identifier.resources.joins(:stash_version).order('version DESC').first.id
-      Version.new(resource_id: res_id)
-    end
-
-    def last_submitted
-      guard_version(get_version_method: :last_submitted_resource)
-    end
-
-    def in_progress
-      guard_version(get_version_method: :in_progress_resource)
-    end
-
-    def guard_version(get_version_method: nil)
-      return nil if @se_identifier.blank? || @se_identifier.resources.count < 1
-      res = @se_identifier.send(get_version_method)
-      return nil if res.nil?
+      res = last_se_resource
+      return nil unless res
       Version.new(resource_id: res.id)
     end
 
     def metadata
       # gets descriptive metadata together
-      lv = in_progress || last_submitted
+      lv = last_version
       return simple_identifier if lv.nil?
       id_size_hsh = id_and_size_hash
       metadata = id_size_hsh.merge(lv.metadata)
@@ -53,9 +43,9 @@ module StashApi
     end
 
     def version_path
-      item = last_submitted || last_version
-      return nil unless item
-      api_url_helper.version_path(item.resource.id)
+      res = last_se_resource
+      return nil unless res
+      api_url_helper.version_path(res.id)
     end
 
     def self_path
@@ -65,9 +55,8 @@ module StashApi
     end
 
     def download_uri
-      # rails will not encode an id wish slashes automatically, and encoding it results in double-encoding
-      # @se_identifier.last_submitted_resource.download_uri
-      return nil unless @se_identifier.last_submitted_resource
+      # rails will not encode an id with slashes automatically, and encoding it results in double-encoding
+      return nil unless @se_identifier.latest_viewable_resource(user: @user)
       path = api_url_helper.download_dataset_path('foobar')
       path.gsub('foobar', CGI.escape(@se_identifier.to_s))
     end

--- a/stash_api/spec/unit/models/stash_api/dataset_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_spec.rb
@@ -84,28 +84,28 @@ module StashApi
 
       it 'shows skipDataciteUpdate when true' do
         @identifier.in_progress_resource.update(skip_datacite_update: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s)
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
         expect(@metadata[:skipDataciteUpdate]).to eq(true)
       end
 
       it 'shows skipEmails when true' do
         @identifier.in_progress_resource.update(skip_emails: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s)
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
         expect(@metadata[:skipEmails]).to eq(true)
       end
 
       it 'shows preserveCurationStatus when true' do
         @identifier.in_progress_resource.update(preserve_curation_status: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s)
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
         expect(@metadata[:preserveCurationStatus]).to eq(true)
       end
 
       it 'shows loosenValidation when true' do
         @identifier.in_progress_resource.update(loosen_validation: true)
-        @dataset = Dataset.new(identifier: @identifier.to_s)
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
         expect(@metadata[:loosenValidation]).to eq(true)
       end

--- a/stash_api/spec/unit/models/stash_api/dataset_spec.rb
+++ b/stash_api/spec/unit/models/stash_api/dataset_spec.rb
@@ -15,6 +15,7 @@ module StashApi
       allow(generic_path).to receive(:dataset_path).and_return('dataset_foobar_path')
       allow(generic_path).to receive(:dataset_versions_path).and_return('dataset_versions_foobar_path')
       allow(generic_path).to receive(:version_path).and_return('version_foobar_path')
+      allow(generic_path).to receive(:download_dataset_path).and_return('download_dataset_foobar_path')
 
       allow(Dataset).to receive(:api_url_helper).and_return(generic_path)
 
@@ -44,7 +45,8 @@ module StashApi
     describe :basic_dataset_view do
 
       before(:each) do
-        @dataset = Dataset.new(identifier: @identifier.to_s)
+        @user.update(role: 'superuser') # need to be superuser to see all dataset info
+        @dataset = Dataset.new(identifier: @identifier.to_s, user: @user)
         @metadata = @dataset.metadata
       end
 

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -101,6 +101,14 @@ module StashEngine
       resources.with_public_metadata.by_version_desc.first
     end
 
+    # these are resources that the user can look at because of permissions, some user roles can see non-published others, not
+    def latest_viewable_resource(user: nil)
+      return latest_resource_with_public_metadata if user.nil?
+      lr = latest_resource
+      return lr if user.id == lr.user_id || user.superuser? || (user.role == 'admin' && user.tenant_id == lr.tenant_id)
+      latest_resource_with_public_metadata
+    end
+
     def last_submitted_version_number
       (lsv = last_submitted_resource) && lsv.version_number
     end


### PR DESCRIPTION
This is for the first part of the ticket at https://github.com/CDL-Dryad/dryad-product-roadmap/issues/301  (basically the parts I've checked).  It's a PR across both Dryad and Stash repos.

The ticket describes it pretty well.

Mainly, any calls for generating dataset display structure for the API (Dataset.new) needs to take a user (or nil for public) because the dataset by default displays the latest version of the metadata that is available for viewing.  Different users will see different latest versions based on their ownership or roles vs the public.

The latest_viewable_resource takes care of most of this, but I needed to be sure the Dataset.new display setup was taking the user so it would calculate the display right.  Also had to change tests and add tests for it, which took some time.