### PR TITLE
PUT/PATCH for API for a Dataset

### DIFF
--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -151,13 +151,13 @@ module StashApi
 
     def do_patch
       content_type = request.headers['content-type']
-      return unless request.method == 'PATCH' && content_type && content_type.start_with?('application/json-patch+json')
+      return unless request.method == 'PATCH' && content_type.present? && content_type.start_with?('application/json-patch+json')
       check_patch_prerequisites { yield }
       check_dataset_completions { yield }
       pre_submission_updates
       StashEngine.repository.submit(resource_id: @resource.id)
       # render something
-      ds = Dataset.new(identifier: @stash_identifier.to_s)
+      ds = Dataset.new(identifier: @stash_identifier.to_s, user: @user)
       render json: ds.metadata, status: 202
       yield
     end


### PR DESCRIPTION
This is part of this ticket.  https://github.com/CDL-Dryad/dryad-product-roadmap/issues/301   I'm doing some testing that changes to security keep these API calls working.  This is mostly testing with only a few code changes this time, but lots of tests.  Both in the Dryad and Stash repos.

The actions I'm testing:

- PATCH as a submission by setting the dataset status.
- PUT to replace the metadata with another set of metadata.
- PUT to "upsert" a new dataset which means insert a specific identifier and update the metadata at the same time (something we added for Dryad).

 I'm trying to just do some sanity checks that these main endpoints work and they have appropriate security based on the API user, their role, etc.  There is a lot of duplication across them since they use the same security before filters so not testing every possible action everywhere and mostly just checking they return results.