### PR TITLE
Journal invoicing

### DIFF
--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -114,11 +114,14 @@ module StashEngine
     # Callbacks
     # ------------------------------------------
     def submit_to_stripe
-      return unless ready_for_payment? &&
-                    resource.identifier&.user_must_pay?
+      return unless ready_for_payment?
 
       inv = Stash::Payments::Invoicer.new(resource: resource, curator: user)
-      inv.charge_via_invoice
+      if resource.identifier&.user_must_pay?
+        inv.charge_user_via_invoice
+      elsif resource.identifier&.journal_will_pay?
+        inv.charge_journal_via_invoice
+      end
     end
 
     def submit_to_datacite

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -216,8 +216,8 @@ module StashEngine
         plan_type == 'DEFERRED'
     end
 
-    def journal_payment_contact
-      contacts =  publication_data('paymentContact')
+    def journal_customer_id
+      publication_data('stripeCustomerID')
     end
 
     def institution_will_pay?

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -216,6 +216,10 @@ module StashEngine
         plan_type == 'DEFERRED'
     end
 
+    def journal_payment_contact
+      contacts =  publication_data('paymentContact')
+    end
+
     def institution_will_pay?
       latest_resource&.tenant&.covers_dpc == true
     end

--- a/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash_engine/lib/stash/payments/invoicer.rb
@@ -54,7 +54,7 @@ module Stash
           customer: customer_id,
           amount: StashEngine.app.payments.data_processing_charge,
           currency: 'usd',
-          description: "Data Processing Charge for #{resource.identifier.to_s}"
+          description: "Data Processing Charge for #{resource.identifier}"
         )
       end
 

--- a/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash_engine/lib/stash/payments/invoicer.rb
@@ -8,16 +8,30 @@ module Stash
         @curator = curator
       end
 
-      def charge_via_invoice
+      # For an end-user, generate an invoice with a single charge
+      # based on the DPC, and immediately finalize the invoice.
+      def charge_user_via_invoice
         set_api_key
-        customer_id = stripe_customer_id
+        customer_id = stripe_user_customer_id
         return unless customer_id.present?
-        add_dpc(customer_id)
+        create_invoice_item_for_dpc(customer_id)
         invoice = create_invoice(customer_id)
         invoice.auto_advance = true
         resource.identifier.invoice_id = invoice.id
         resource.identifier.save
         invoice.finalize_invoice
+      end
+
+      # For a journal, generate an invoice item for the DPC.
+      # Don't create the actual invoice, because we don't want to
+      # send it until the end of the month.
+      def charge_journal_via_invoice
+        set_api_key
+        customer_id = stripe_journal_customer_id
+        return unless customer_id.present?
+        create_invoice_item_for_dpc(customer_id)
+        resource.identifier.invoice_id = "journal_invoice:#{customer_id}"
+        resource.identifier.save
       end
 
       def external_service_online?
@@ -35,7 +49,7 @@ module Stash
         Stripe.api_key = StashEngine.app.payments.key
       end
 
-      def add_dpc(customer_id)
+      def create_invoice_item_for_dpc(customer_id)
         Stripe::InvoiceItem.create(
           customer: customer_id,
           amount: StashEngine.app.payments.data_processing_charge,
@@ -59,11 +73,15 @@ module Stash
         )
       end
 
-      def stripe_customer_id
-        ensure_customer_id_exists
+      def stripe_user_customer_id
+        ensure_user_customer_id_exists
       end
 
-      def ensure_customer_id_exists
+      def stripe_journal_customer_id
+        resource.identifier&.journal_payment_contact
+      end
+
+      def ensure_user_customer_id_exists
         # Retrieve the primary author for the dataset
         author = StashEngine::Author.primary(resource.id)
         return if author.blank?

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -70,7 +70,7 @@ module StashEngine
         allow_any_instance_of(Stash::Doi::IdGen).to receive(:make_instance).and_return(true)
         allow_any_instance_of(Stash::Doi::IdGen).to receive(:update_identifier_metadata).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:new).and_return(true)
-        allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_via_invoice).and_return(true)
+        allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_user_via_invoice).and_return(true)
       end
 
       context :update_solr do

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -249,6 +249,22 @@ module StashEngine
       end
     end
 
+    describe '#journal_customer_id' do
+      it 'retrieves the journal Stripe customer ID' do
+        @fake_journal_name = 'Fake Journal'
+        @fake_customer_id = 'cust_abc123'
+        stub_request(:any, %r{/journals/#{@fake_issn}})
+          .to_return(body: '{"fullName":"' + @fake_journal_name + '",
+                             "issn":"' + @fake_issn + '",
+                             "website":"http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-294X",
+                             "description":"Molecular Ecology publishes papers that utilize molecular genetic techniques...",
+                             "stripeCustomerID":"' + @fake_customer_id + '"}',
+                     status: 200,
+                     headers: { 'Content-Type' => 'application/json' })
+        expect(identifier.journal_customer_id).to eq(@fake_customer_id)
+      end
+    end
+
     describe '#journal_will_pay?' do
       it 'returns true when there is a PREPAID plan' do
         allow(@identifier).to receive('publication_data').and_return('PREPAID')

--- a/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -55,8 +55,6 @@ module Stash
         allow(StashEngine::Author).to receive(:primary).with(@resource_id).and_return(nil)
         expect(@invoicer.charge_user_via_invoice).to eql(nil)
       end
-
-      
     end
   end
 end

--- a/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -27,6 +27,7 @@ module Stash
         allow(@author).to receive(:id).and_return(9)
         allow(@author).to receive(:author_email).and_return('jane.doe@example.org')
         allow(@author).to receive(:author_standard_name).and_return('Jane Doe')
+        allow(@author).to receive(:stripe_customer_id).and_return(nil)
 
         @cust_id = '9999'
         fake_invoice_item = OpenStruct.new(customer: @cust_id, amount: '99.99', currency: 'usd', description: 'Data Processing Charge')
@@ -48,6 +49,7 @@ module Stash
 
       it 'creates an invoice for an existing stripe customer' do
         allow(@invoicer).to receive(:lookup_prior_stripe_customer_id).and_return('999911')
+        allow(@author).to receive(:stripe_customer_id).and_return('999911')
         expect(@invoicer.charge_user_via_invoice).to eql('STRIPE1234')
       end
 

--- a/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -56,6 +56,7 @@ module Stash
         expect(@invoicer.charge_user_via_invoice).to eql(nil)
       end
 
+      
     end
   end
 end

--- a/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -36,24 +36,24 @@ module Stash
 
         @invoicer = Invoicer.new(resource: @resource, curator: @curator)
         allow(@invoicer).to receive(:set_api_key).and_return(true)
-        allow(@invoicer).to receive(:add_dpc).and_return(fake_invoice_item)
+        allow(@invoicer).to receive(:create_invoice_item_for_dpc).and_return(fake_invoice_item)
         allow(@invoicer).to receive(:create_invoice).and_return(fake_invoice)
         allow(@invoicer).to receive(:create_customer).and_return(fake_customer)
         allow(@invoicer).to receive(:lookup_prior_stripe_customer_id).and_return(nil)
       end
 
       it 'creates an invoice for a new stripe customer' do
-        expect(@invoicer.charge_via_invoice).to eql('STRIPE1234')
+        expect(@invoicer.charge_user_via_invoice).to eql('STRIPE1234')
       end
 
       it 'creates an invoice for an existing stripe customer' do
         allow(@invoicer).to receive(:lookup_prior_stripe_customer_id).and_return('999911')
-        expect(@invoicer.charge_via_invoice).to eql('STRIPE1234')
+        expect(@invoicer.charge_user_via_invoice).to eql('STRIPE1234')
       end
 
       it 'does not create an invoice when the resource has no primary author' do
         allow(StashEngine::Author).to receive(:primary).with(@resource_id).and_return(nil)
-        expect(@invoicer.charge_via_invoice).to eql(nil)
+        expect(@invoicer.charge_user_via_invoice).to eql(nil)
       end
 
     end


### PR DESCRIPTION
When a dataset is published, and the associated journal is paying, add an "InvoiceItem" to their Stripe account. See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/235

To test (on dryad-dev):
- Create a new dataset
- Select "Manuscript in Progress"
- Enter the journal name "The American Naturalist" (this is the only journal currently set up in Stripe)
- Complete the submission, verifying that the review page states that the journal will pay
- Go to the Admin page, and find the dataset
- Change its status to "published"
- Verify that the journal has been invoiced, either by viewing the journal's customer page in Stripe, or by viewing the database field `stash_engine_identifiers.invoice_id`