### PR TITLE
Versions API Security

### DIFF
--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -474,13 +474,15 @@ module StashEngine
     # 3. if not public then the author can still download: resource.user_id = current_user.id
     # 4. if not public then the current user has the 'superuser' role for seeing all files
     # Note: the special download links mean anyone with that link may download and this doesn't apply
+    # rubocop:disable Metrics/CyclomaticComplexity
     def may_download?(ui_user: nil) # doing this to avoid collision with the association called user
       return false unless current_resource_state&.resource_state == 'submitted' # merritt state available
       return true if files_published? # curation state of public or embargoed and expired
       return false if ui_user.blank? # the rest of the cases require users
-      return true if ui_user.id == user_id || ui_user.role == 'superuser' # owner viewing or superuser viewing
+      return true if ui_user.id == user_id || ui_user.role == 'superuser' || (ui_user.role == 'admin' && ui_user.tenant_id == tenant_id)
       false # nope. Not sure if it would ever get here, though
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # see if the user may view based on curation status & roles and etc.  I don't see this as being particularly complex for Rubocop
     # rubocop:disable Metrics/CyclomaticComplexity

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -482,6 +482,16 @@ module StashEngine
       false # nope. Not sure if it would ever get here, though
     end
 
+    # see if the user may view based on curation status & roles and etc.  I don't see this as being particularly complex for Rubocop
+    # rubocop:disable Metrics/CyclomaticComplexity
+    def may_view?(ui_user: nil)
+      return true if metadata_published? # anyone can view
+      return false if ui_user.blank? # otherwise unknown person can't view and this prevents later nil checks
+      return true if user_id == ui_user.id || ui_user.superuser? || (ui_user.role == 'admin' && ui_user.tenant_id == tenant_id)
+      false
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+
     # ------------------------------------------------------------
     # Usage and statistics
 

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -177,6 +177,18 @@ module StashEngine
       joins(JOIN_FOR_LATEST_CURATION).where(str, *arr)
     end
 
+    scope :visible_to_user, ->(user:) do
+      if user.nil?
+        with_visibility(states: %w[published embargoed])
+      elsif user.superuser?
+        all
+      elsif user.role == 'admin'
+        with_visibility(states: %w[published embargoed], tenant_id: user.tenant_id)
+      else
+        with_visibility(states: %w[published embargoed], user_id: user.id)
+      end
+    end
+
     # gets the latest version per dataset and includes items that haven't been assigned an identifer yet but are initially in progress
     # NOTE.  We've now changed it so everything gets an identifier upon creation, so we may be able to simplify or get rid of this.
     scope :latest_per_dataset, (-> do

--- a/stash_engine/spec/db/stash_engine/resource_spec.rb
+++ b/stash_engine/spec/db/stash_engine/resource_spec.rb
@@ -1127,7 +1127,8 @@ module StashEngine
         end
       end
 
-      describe :with_visibility do
+      describe :curation_visibility_setup do
+
         before(:each) do
           # user has only user permission and is part of the UCOP tenant
           @user2 = create(:user, first_name: 'Gargola', last_name: 'Jones', email: 'luckin@ucop.edu', tenant_id: 'ucop', role: 'admin')
@@ -1185,28 +1186,67 @@ module StashEngine
 
         end
 
-        it 'lists publicly viewable (two curation states) in one query' do
-          public_resources = Resource.with_visibility(states: %w[published embargoed])
-          expect(public_resources.count).to eq(6)
-          expect(public_resources.map(&:id)).to include(@resources[0].id)
+        describe :with_visibility do
+          it 'lists publicly viewable (two curation states) in one query' do
+            public_resources = Resource.with_visibility(states: %w[published embargoed])
+            expect(public_resources.count).to eq(6)
+            expect(public_resources.map(&:id)).to include(@resources[0].id)
+          end
+
+          it 'lists publicly viewable and private in my tenant for admins' do
+            resources = Resource.with_visibility(states: %w[published embargoed], user_id: nil, tenant_id: 'ucop')
+            expect(resources.count).to eq(8)
+            expect(resources.map(&:id)).to include(@resources[3].id)
+          end
+
+          it 'lists publicly viewable and my own datasets for a user' do
+            resources = Resource.with_visibility(states: %w[published embargoed], user_id: @user.id)
+            expect(resources.count).to eq(7)
+            expect(resources.map(&:id)).to include(@resources[2].id)
+          end
+
+          it 'only picks up the final state for each dataset' do
+            resources = Resource.with_visibility(states: 'curation')
+            expect(resources.count).to eq(1)
+            expect(resources.map(&:id)).to include(@resources[2].id)
+          end
         end
 
-        it 'lists publicly viewable and private in my tenant for admins' do
-          resources = Resource.with_visibility(states: %w[published embargoed], user_id: nil, tenant_id: 'ucop')
-          expect(resources.count).to eq(8)
-          expect(resources.map(&:id)).to include(@resources[3].id)
-        end
+        # this can test more or less the same stuff as "with visibility" but automatically modifies for the user and
+        # their role.  I think will mostly be used for getting resources for an identifier visible to a user and their role.
+        describe :visible_to_user do
+          before(:each) do
+            @identifier = Identifier.create(identifier: 'cat/dog', identifier_type: 'DOI')
+            @resources[0].update(identifier_id: @identifier.id)
+            @resources[1].update(identifier_id: @identifier.id)
+            @resources[2].update(identifier_id: @identifier.id)
+          end
 
-        it 'lists publicly viewable and my own datasets for a user' do
-          resources = Resource.with_visibility(states: %w[published embargoed], user_id: @user.id)
-          expect(resources.count).to eq(7)
-          expect(resources.map(&:id)).to include(@resources[2].id)
-        end
+          it 'shows all resources for the identifier to the superuser' do
+            resources = @identifier.resources.visible_to_user(user: @user3)
+            expect(resources.count).to eq(3)
+          end
 
-        it 'only picks up the final state for each dataset' do
-          resources = Resource.with_visibility(states: 'curation')
-          expect(resources.count).to eq(1)
-          expect(resources.map(&:id)).to include(@resources[2].id)
+          it 'shows all resources to the owner' do
+            resources = @identifier.resources.visible_to_user(user: @user3)
+            expect(resources.count).to eq(3)
+          end
+
+          it 'only shows curated-visible resources to a non-user' do
+            resources = @identifier.resources.visible_to_user(user: nil)
+            expect(resources.count).to eq(2)
+          end
+
+          it 'shows all resources to an admin for this tenant (ucop)' do
+            resources = @identifier.resources.visible_to_user(user: @user2)
+            expect(resources.count).to eq(3)
+          end
+
+          it 'only shows curated-visible resources to a random user' do
+            @user4 = create(:user, first_name: 'Gorgon', last_name: 'Grup', email: 'st38p@ucop.edu', tenant_id: 'ucb', role: 'user')
+            resources = @identifier.resources.visible_to_user(user: @user4)
+            expect(resources.count).to eq(2)
+          end
         end
       end
     end


### PR DESCRIPTION
This applies to both Dryad and stash repos. https://github.com/CDL-Dryad/dryad-product-roadmap/issues/363  .  It puts security for user/role on all versions endpoints with tests.  I also needed to update the download to use the streaming download instead of redirecting the versions download to Merritt.

