### PR TITLE
Added handling for Datacite errors for curation status changes (updates)

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -73,9 +73,19 @@ module StashEngine
           @resource.publication_date = @pub_date
           @resource.hold_for_peer_review = true if @status == 'peer_review'
           @resource.peer_review_end_date = (Time.now + 6.months) if @status == 'peer_review'
-          @resource.curation_activities << CurationActivity.create(user_id: current_user.id, status: @status,
-                                                                   note: params[:resource][:curation_activity][:note])
-          @resource.save
+          begin
+            @resource.curation_activities << CurationActivity.create(user_id: current_user.id, status: @status,
+                                                                     note: params[:resource][:curation_activity][:note])
+            @resource.save
+          rescue Stash::Doi::DataciteError
+            # Datacite had a submission error (often due to them onlly hanging on to test DOIs for a short
+            # period of time), so disable datacite submission and try again
+            logger.error "Unable to send metadata to Datacite for #{@resource.identifier.to_s}"
+            @resource.update(skip_datacite_update: true)
+            CurationActivity.create(user_id: current_user.id, status: @status, resource_id: @resource.id,
+                                    note: params[:resource][:curation_activity][:note])
+            @resource.update(skip_datacite_update: false)
+          end
           @resource.reload
         end
       end

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -53,7 +53,8 @@ module StashEngine
     # ------------------------------------------
     # When the status is published/embargoed send to Stripe and DataCite
     after_create :submit_to_datacite, :update_solr, :submit_to_stripe,
-                 if: proc { |ca| (ca.published? || ca.embargoed?) && latest_curation_status_changed? }
+                 if: proc { |ca| !ca.resource.skip_datacite_update? && (ca.published? || ca.embargoed?) &&
+                                 latest_curation_status_changed? }
 
     # Email the primary author when submitted, peer_review, published or embargoed
     after_create :email_author,

--- a/stash_engine/lib/stash/doi/datacite_gen.rb
+++ b/stash_engine/lib/stash/doi/datacite_gen.rb
@@ -51,7 +51,7 @@ module Stash
       end
 
       def validate_response(response:, operation:)
-        raise DataciteError, "DataCite failed to #{operation} for resource #{resource.id}" unless response.status == 201
+        raise DataciteError, "DataCite failed to #{operation} for resource #{resource.id} - Status: #{response.status}" unless response.status == 201
       end
 
     end


### PR DESCRIPTION
For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/376

The Datacite 403 error is due to test DOIs that have been removed by Datacite. This change disables the data cite submission and then tries to create the new curation activity again.