### PR TITLE
added index to stash_engine_internal_data.identifier_id

### DIFF
--- a/stash_engine/db/migrate/20190715204229_add_index_to_stash_engine_internal_data.rb
+++ b/stash_engine/db/migrate/20190715204229_add_index_to_stash_engine_internal_data.rb
@@ -1,0 +1,5 @@
+class AddIndexToStashEngineInternalData < ActiveRecord::Migration
+  def change
+    add_index :stash_engine_internal_data, :identifier_id
+  end
+end


### PR DESCRIPTION
Related to: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/359

@sfisher I manually added an index to the InternalDatum table on the migration server to address some issues we discovered while you were on vacation. I just remembered that I had not added a formal PR for the migration.