### PR TITLE
Updated link on homepage to point to membership info

### DIFF
--- a/stash_engine/app/views/stash_engine/pages/home.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/home.html.erb
@@ -7,7 +7,7 @@
     <div class="o-quote__quote">
       Dryad is a community-owned resource.
       <br>
-      <a href="#" class="o-quote__quote">Learn more about our organizational memberships.</a>
+      <a href="<%= stash_url_helpers.about_path(anchor: 'membership') %>" class="o-quote__quote">Learn more about our organizational memberships.</a>
     </div>
   </div>
   <div class="t-home__search o-home-search">


### PR DESCRIPTION
Just noticed that the link in the grey box on the homepage was not sending users to the membership info, so this patch just updates the href.