### PR TITLE
This fixes display problems with the counter stats & some optimizations

### DIFF
--- a/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -5,22 +5,19 @@ module StashEngine
     # this class wraps around some database accessors to cache them so we don't query the same stats more than once
     # per day because that is the max time that we update stats
 
-    # these override the default ActiveRecord readers for these fields so it updates
-    # the cache if necessary before reading (the read_attribute in the method, gets the
-    # AR field instead of re-calling the same named method)
-    def unique_investigation_count
+    def check_unique_investigation_count
       update_if_necessary
-      read_attribute(:unique_investigation_count)
+      unique_investigation_count
     end
 
-    def unique_request_count
+    def check_unique_request_count
       update_if_necessary
-      read_attribute(:unique_request_count)
+      unique_request_count
     end
 
-    def citation_count
+    def check_citation_count
       update_if_necessary
-      read_attribute(:citation_count)
+      citation_count
     end
 
     # try this doi, at least on test 10.7291/d1q94r
@@ -33,8 +30,7 @@ module StashEngine
       # only update stats if it's after the date of the last updated date for record
       return unless new_record? || updated_at.nil? || Time.new.localtime.to_date > updated_at.localtime.to_date
       update_usage!
-      update_citation_count!
-
+      # update_citation_count!
       self.updated_at = Time.new # seem to need this for some reason
 
       save!

--- a/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -30,7 +30,7 @@ module StashEngine
       # only update stats if it's after the date of the last updated date for record
       return unless new_record? || updated_at.nil? || Time.new.localtime.to_date > updated_at.localtime.to_date
       update_usage!
-      # update_citation_count!
+      update_citation_count!
       self.updated_at = Time.new # seem to need this for some reason
 
       save!

--- a/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
@@ -5,7 +5,7 @@
     <!-- <span class="o-metrics__label">views</span> -->
   </div>
   <div class="o-metrics__number">
-    <%= identifier.counter_stat.unique_investigation_count - identifier.counter_stat.unique_request_count %> views
+    <%= identifier.counter_stat.check_unique_investigation_count - identifier.check_counter_stat.check_unique_request_count %> views
   </div>
 </div>
 <div class="o-metrics__metric">
@@ -13,7 +13,7 @@
     <%= image_tag 'stash_engine/icon_downloads.svg', class: 'o-metrics__icon', alt: '' %>
     <!-- <span class="o-metrics__label">downloads</span> -->
   </div>
-  <div class="o-metrics__number"><%= identifier.counter_stat.unique_request_count %> downloads</div>
+  <div class="o-metrics__number"><%= identifier.counter_stat.check_unique_request_count %> downloads</div>
 </div>
 <div class="o-metrics__metric">
   <div class="o-metrics__group">
@@ -21,11 +21,11 @@
     <!-- <span class="o-metrics__label">citations</span> -->
   </div>
   <div class="o-metrics__number" id="metrics_citation_count">
-    <% if identifier.counter_stat.citation_count > 0 %>
-      <%= link_to "#{identifier.counter_stat.citation_count} citations", stash_url_helpers.show_citations_path(identifier_id: identifier.id),
+    <% if identifier.counter_stat.check_citation_count > 0 %>
+      <%= link_to "#{identifier.counter_stat.check_citation_count} citations", stash_url_helpers.show_citations_path(identifier_id: identifier.id),
                   id: 'citation_link', remote: true %>
     <% else %>
-      <%= identifier.counter_stat.citation_count %> citations
+      <%= identifier.counter_stat.check_citation_count %> citations
     <% end %>
   </div>
   <div class="o-metrics__number" id="metrics_citation_spinner" style="display: none;">

--- a/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_metrics.html.erb
@@ -5,7 +5,7 @@
     <!-- <span class="o-metrics__label">views</span> -->
   </div>
   <div class="o-metrics__number">
-    <%= identifier.counter_stat.check_unique_investigation_count - identifier.check_counter_stat.check_unique_request_count %> views
+    <%= identifier.counter_stat.check_unique_investigation_count - identifier.counter_stat.check_unique_request_count %> views
   </div>
 </div>
 <div class="o-metrics__metric">

--- a/stash_engine/lib/stash/event_data.rb
+++ b/stash_engine/lib/stash/event_data.rb
@@ -1,6 +1,7 @@
 # EventData is the DataCite API for getting stats about citations and usage.
 # They currently do not have totals so we need to get large swaths of data and add it up on the client side instead
 # of doing it a database where it is probably easier and more efficient.
+require 'byebug'
 module Stash
   module EventData
     Dir.glob(File.expand_path('event_data/*.rb', __dir__)).sort.each(&method(:require))

--- a/stash_engine/lib/stash/event_data.rb
+++ b/stash_engine/lib/stash/event_data.rb
@@ -15,7 +15,7 @@ module Stash
     protected
 
     def generic_query(params:)
-      hash = { 'mailto'  =>  @email } # this was for crossref, but doesn't hurt for DataCite so they can contact us if there are problems
+      hash = { 'mailto' => @email } # this was for crossref, but doesn't hurt for DataCite so they can contact us if there are problems
       response = make_reliable { RestClient.get @base_url, params: hash.merge(params) }
       JSON.parse(response.body)
     end

--- a/stash_engine/lib/stash/event_data.rb
+++ b/stash_engine/lib/stash/event_data.rb
@@ -1,12 +1,12 @@
 # EventData is the DataCite API for getting stats about citations and usage.
 # They currently do not have totals so we need to get large swaths of data and add it up on the client side instead
 # of doing it a database where it is probably easier and more efficient.
-require 'byebug'
+
 module Stash
   module EventData
     Dir.glob(File.expand_path('event_data/*.rb', __dir__)).sort.each(&method(:require))
 
-    TIME_BETWEEN_RETRIES = 0.8
+    TIME_BETWEEN_RETRIES = 1
     def logger
       Rails.logger
     end
@@ -15,10 +15,7 @@ module Stash
     protected
 
     def generic_query(params:)
-      hash = {
-        'mailto'  =>  @email,
-        'rows'    =>  10_000, # this one for crossref
-      }
+      hash = { 'mailto'  =>  @email } # this was for crossref, but doesn't hurt for DataCite so they can contact us if there are problems
       response = make_reliable { RestClient.get @base_url, params: hash.merge(params) }
       JSON.parse(response.body)
     end

--- a/stash_engine/lib/stash/event_data.rb
+++ b/stash_engine/lib/stash/event_data.rb
@@ -5,6 +5,7 @@ module Stash
   module EventData
     Dir.glob(File.expand_path('event_data/*.rb', __dir__)).sort.each(&method(:require))
 
+    TIME_BETWEEN_RETRIES = 0.8
     def logger
       Rails.logger
     end
@@ -28,7 +29,7 @@ module Stash
       rescue RestClient::InternalServerError => ex
         raise ex if retries < 1
         retries -= 1
-        sleep 0.6
+        sleep TIME_BETWEEN_RETRIES
         retry
       end
     end

--- a/stash_engine/lib/stash/event_data/citations.rb
+++ b/stash_engine/lib/stash/event_data/citations.rb
@@ -12,7 +12,6 @@ module Stash
       # This domain they say is what I should use, but it returns blank strings and no json
       # BASE_URL = 'https://api.test.datacite.org/events'.freeze
       BASE_URL = 'https://api.datacite.org/events'.freeze
-      EMAIL = 'scott.fisher@ucop.edu'.freeze
       DATACITE_URL = 'https://doi.org/'.freeze
 
       OTHERS_CITING_ME = %w[cites describes is-supplemented-by references compiles reviews requires has-metadata documents
@@ -24,7 +23,7 @@ module Stash
         @doi = doi&.downcase # had lots of problems from DataCite eventdata with an upcase and DOIs are supposed to be case insensitive
         @doi = doi[4..-1] if doi.start_with?('doi:')
         @base_url = BASE_URL
-        @email = EMAIL
+        @email = APP_CONFIG&.contact_email&.first
       end
 
       # response.headers -- includes :content_type=>"application/json;charset=UTF-8"

--- a/stash_engine/lib/stash/event_data/citations.rb
+++ b/stash_engine/lib/stash/event_data/citations.rb
@@ -8,16 +8,16 @@ module Stash
       include Stash::EventData
 
       attr_reader :doi
-      # This first domain worked earlier this week though with intermittant 500 errors
-      # DOMAIN = 'https://query.eventdata.crossref.org'.freeze
 
       # This domain they say is what I should use, but it returns blank strings and no json
-      BASE_URL = 'https://api.eventdata.crossref.org/v1/events'.freeze
+      # BASE_URL = 'https://api.test.datacite.org/events'.freeze
+      BASE_URL = 'https://api.datacite.org/events'.freeze
       EMAIL = 'scott.fisher@ucop.edu'.freeze
-      # only keep these relations from these sources, based on https://support.datacite.org/v1.1/docs/eventdata-query-api-guide
-      # DATACITE_INCLUDE = %w[is_cited_by is_supplement_to is_referenced_by is_compiled_by is_source_of is_required_by].freeze
-      # CROSSREF_INCLUDE = %w[cites is_supplemented_by compiles requires references].freeze
-      EXCLUDE_LIST = %w[has_version is_version_of is_new_version_of is_previous_version_of is_identical_to].freeze
+      DATACITE_URL = 'https://doi.org/'
+
+      OTHERS_CITING_ME = %w[cites describes references documents is-supplemented-by]
+      ME_CLAIMING_CITATION = %w[is-cited-by is-described-by is-referenced-by is-documented-by is-supplement-to]
+      # We are not currently using the other way of looking up, but might have to if searching for subjects with this object doesn't work
 
       def initialize(doi:)
         @doi = doi
@@ -26,35 +26,15 @@ module Stash
         @email = EMAIL
       end
 
-      def results
-        # put the results into hash by keys, values so we can merge them and eliminate duplicate keys
-        datacite_results = datacite_query.map { |x| [x['obj_id'], x] }.to_h
-        crossref_results = crossref_query.map { |x| [x['subj_id'], x] }.to_h
-        # this merge should overwrite duplicate DOI keys, preferring datacite over crossref and convert back to array
-        crossref_results.merge(datacite_results).values
-      end
-
-      # response.code == 200
       # response.headers -- includes :content_type=>"application/json;charset=UTF-8"
+      def results
+        params = {'obj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': OTHERS_CITING_ME.join(','), 'page[size]': 10_000}
+        res = generic_query(params: params)
+        res['data'].map{|i| i['attributes']['subj-id']}.uniq
 
-      # can test with '10.5061/dryad.n81g1'
-      # to get the actual citation link you'd use obj_id
-      def datacite_query
-        generic_query(params: { source: 'datacite', 'subj-id': @doi })['message']['events']
-          .reject { |item| EXCLUDE_LIST.include?(item['relation_type_id']) }
+        # I think I need to flip this query, also and do ME_CLAIMING_CITATION and subj-id.
       rescue RestClient::ExceptionWithResponse => err
-        logger.error("#{Time.new} Could not get response from CrossRef for DataCite event data source:datacite,subj-id:#{@doi}")
-        logger.error("#{Time.new} #{err}")
-        []
-      end
-
-      # can test with '10.13140/RG.2.1.1350.3122'
-      # to get the actual citation link for this DOI you'd use subj_id doi
-      def crossref_query
-        generic_query(params: { source: 'crossref', 'obj-id': @doi })['message']['events']
-          .reject { |item| EXCLUDE_LIST.include?(item['relation_type_id']) }
-      rescue RestClient::ExceptionWithResponse => err
-        logger.error("#{Time.new} Could not get response from CrossRef for CrossRef event data source:crossref,obj-id:#{@doi}")
+        logger.error("#{Time.new} Could not get citations from DataCite for event data obj-id: #{DATACITE_URL}#{@doi}")
         logger.error("#{Time.new} #{err}")
         []
       end

--- a/stash_engine/lib/stash/event_data/citations.rb
+++ b/stash_engine/lib/stash/event_data/citations.rb
@@ -1,7 +1,6 @@
 require 'rest-client'
 require 'json'
 require 'cgi'
-require 'byebug'
 
 module Stash
   module EventData
@@ -14,12 +13,12 @@ module Stash
       # BASE_URL = 'https://api.test.datacite.org/events'.freeze
       BASE_URL = 'https://api.datacite.org/events'.freeze
       EMAIL = 'scott.fisher@ucop.edu'.freeze
-      DATACITE_URL = 'https://doi.org/'
+      DATACITE_URL = 'https://doi.org/'.freeze
 
       OTHERS_CITING_ME = %w[cites describes is-supplemented-by references compiles reviews requires has-metadata documents
-        is-source-of].freeze
+                            is-source-of].freeze
       ME_CLAIMING_CITATION = %w[is-cited-by is-supplement-to is-described-by is-metadata-for is-referenced-by
-        is-documented-by is-compiled-by is-reviewed-by is-derived-from is-required-by].freeze
+                                is-documented-by is-compiled-by is-reviewed-by is-derived-from is-required-by].freeze
 
       def initialize(doi:)
         @doi = doi&.downcase # had lots of problems from DataCite eventdata with an upcase and DOIs are supposed to be case insensitive
@@ -30,12 +29,12 @@ module Stash
 
       # response.headers -- includes :content_type=>"application/json;charset=UTF-8"
       def results
-        params = {'page[size]': 10_000}
+        params = { 'page[size]': 10_000 }
         result1 = generic_query(params: params.merge('obj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': OTHERS_CITING_ME.join(',')))
-        array1 = result1['data'].map{|i| i['attributes']['subj-id']}
+        array1 = result1['data'].map { |i| i['attributes']['subj-id'] }
 
         result2 = generic_query(params: params.merge('subj-id': "#{DATACITE_URL}#{@doi}", 'relation-type-id': ME_CLAIMING_CITATION.join(',')))
-        array2 = result2['data'].map{|i| i['attributes']['obj-id']}
+        array2 = result2['data'].map { |i| i['attributes']['obj-id'] }
 
         (array1 | array2) # returns the union of two sets, which deduplicates identical items, even if in the same original array
       rescue RestClient::ExceptionWithResponse => err

--- a/stash_engine/lib/stash/event_data/usage.rb
+++ b/stash_engine/lib/stash/event_data/usage.rb
@@ -45,7 +45,7 @@ module Stash
       def unique_dataset_investigations_count
         stats.inject(0) do |sum, item|
           if UNIQUE_INVESTIGATIONS.include?(item['id'])
-            sum + item['year-months'].inject(0) { |sum2, x| sum2 + x['sum'] }.to_i
+            sum + item['count'].to_i
           else
             sum
           end
@@ -55,7 +55,7 @@ module Stash
       def unique_dataset_requests_count
         stats.inject(0) do |sum, item|
           if UNIQUE_REQUESTS.include?(item['id'])
-            sum + item['year-months'].inject(0) { |sum2, x| sum2 + x['sum'] }.to_i
+            sum + item['count'].to_i
           else
             sum
           end
@@ -64,9 +64,8 @@ module Stash
 
       def query
         query_result = generic_query(params:
-          { 'source-id' => 'datacite-usage', 'doi' => @doi, 'page[size]' => 0,
+          { 'source-id' => 'datacite-usage', 'doi' => @doi, 'page[size]' => 0, 'rows' => nil,
             'relation-type-id' => (UNIQUE_INVESTIGATIONS + UNIQUE_REQUESTS).join(',') })
-
         query_result['meta']['relation-types'] || []
       rescue RestClient::ExceptionWithResponse => err
         logger.error('DataCite event-data error')

--- a/stash_engine/lib/stash/event_data/usage.rb
+++ b/stash_engine/lib/stash/event_data/usage.rb
@@ -11,7 +11,7 @@ module Stash
 
       # BASE_URL = 'https://api.test.datacite.org/events'.freeze
       BASE_URL = 'https://api.datacite.org/events'.freeze
-      HEARTBEAT_URL = 'https://api.test.datacite.org/heartbeat'.freeze
+      HEARTBEAT_URL = 'https://api.datacite.org/heartbeat'.freeze
       EMAIL = 'scott.fisher@ucop.edu'.freeze
       UNIQUE_INVESTIGATIONS = %w[unique-dataset-investigations-regular unique-dataset-investigations-machine].freeze
       UNIQUE_REQUESTS = %w[unique-dataset-requests-regular unique-dataset-requests-machine].freeze
@@ -73,34 +73,6 @@ module Stash
         logger.error("#{Time.new} #{err}")
         []
       end
-
-      # try this doi, at least on test 10.7291/d1q94r
-      # or how about this one? doi:10.7272/Q6Z60KZD
-      # or this one has machine hits, I think.  doi:10.6086/D1H59V
-
-      # can't set large page sizes so have to keep following ['links']['next'] until no more to follow
-      # and they currently don't allow us to query totals
-
-      # this is the old query, going through pages, they changed their api
-      def old_query
-        data = []
-
-        query_result = generic_query(params: { 'source-id': 'datacite-usage', 'doi': @doi })
-        data += query_result['data'] if query_result['data']
-
-        while query_result['links']['next']
-          query_result = make_reliable { RestClient.get query_result['links']['next'] }
-          query_result = JSON.parse(query_result)
-          data += query_result['data'] if query_result['data']
-        end
-
-        data
-      rescue RestClient::ExceptionWithResponse => err
-        logger.error("#{Time.new} Could not get response from DataCite event data source-id=datacite-usage&doi=#{CGI.escape(@doi)}")
-        logger.error("#{Time.new} #{err}")
-        []
-      end
-
     end
   end
 end

--- a/stash_engine/spec/data/event-data-citations1.json
+++ b/stash_engine/spec/data/event-data-citations1.json
@@ -1,0 +1,89 @@
+{
+  "data": [
+    {
+      "id": "1baea678-6267-4e0e-ac18-3b7a1b7cf89c",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://doi.org/10.1126/sciadv.1602232",
+        "obj-id": "https://doi.org/10.6071/m3rp49",
+        "source-id": "datacite-crossref",
+        "relation-type-id": "is-supplemented-by",
+        "total": 1,
+        "message-action": "create",
+        "source-token": "28276d12-b320-41ba-9272-bb0adc3466ff",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2019-03-05T20:32:29.000Z",
+        "timestamp": "2019-03-05T20:32:36.843Z"
+      },
+      "relationships": {
+        "subj": {
+          "data": {
+            "id": "https://doi.org/10.1126/sciadv.1602232",
+            "type": "objects"
+          }
+        },
+        "obj": {
+          "data": {
+            "id": "https://doi.org/10.6071/m3rp49",
+            "type": "objects"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total": 1,
+    "total-pages": 1,
+    "page": 1,
+    "sources": [
+      {
+        "id": "datacite-crossref",
+        "title": "DataCite to Crossref",
+        "count": 1
+      }
+    ],
+    "prefixes": [
+      {
+        "id": "10.6071",
+        "title": "10.6071",
+        "count": 1
+      },
+      {
+        "id": "10.1126",
+        "title": "10.1126",
+        "count": 1
+      }
+    ],
+    "citation-types": [
+      {
+        "id": "Collection-ScholarlyArticle",
+        "title": "Collection-ScholarlyArticle",
+        "count": 1,
+        "year-months": [
+          {
+            "id": "2019-03",
+            "title": "March 2019",
+            "sum": 1.0
+          }
+        ]
+      }
+    ],
+    "relation-types": [
+      {
+        "id": "is-supplement-to",
+        "title": "is-supplement-to",
+        "count": 1.0,
+        "year-months": [
+          {
+            "id": "2019-03",
+            "title": "March 2019",
+            "sum": 1.0
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "https://api.datacite.org/events?mailto=scott.fisher%40ucop.edu&page%5Bsize%5D=10000&obj-id=https%3A%2F%2Fdoi.org%2F10.6071%2Fm3rp49&relation-type-id=cites%2Cdescribes%2Cis-supplemented-by%2Creferences%2Ccompiles%2Creviews%2Crequires%2Chas-metadata%2Cdocuments%2Cis-source-of"
+  }
+}

--- a/stash_engine/spec/data/event-data-citations2.json
+++ b/stash_engine/spec/data/event-data-citations2.json
@@ -1,0 +1,89 @@
+{
+  "data": [
+    {
+      "id": "3e04b382-d3d4-4c86-9569-3e7fcb43f08e",
+      "type": "events",
+      "attributes": {
+        "subj-id": "https://doi.org/10.6071/m3rp49",
+        "obj-id": "https://doi.org/10.1098/rsif.2017.0030",
+        "source-id": "datacite-crossref",
+        "relation-type-id": "is-supplement-to",
+        "total": 1,
+        "message-action": "create",
+        "source-token": "28276d12-b320-41ba-9272-bb0adc3466ff",
+        "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "occurred-at": "2019-03-05T20:32:29.000Z",
+        "timestamp": "2019-03-05T20:32:36.921Z"
+      },
+      "relationships": {
+        "subj": {
+          "data": {
+            "id": "https://doi.org/10.6071/m3rp49",
+            "type": "objects"
+          }
+        },
+        "obj": {
+          "data": {
+            "id": "https://doi.org/10.1098/rsif.2017.0030",
+            "type": "objects"
+          }
+        }
+      }
+    }
+  ],
+  "meta": {
+    "total": 1,
+    "total-pages": 1,
+    "page": 1,
+    "sources": [
+      {
+        "id": "datacite-crossref",
+        "title": "DataCite to Crossref",
+        "count": 1
+      }
+    ],
+    "prefixes": [
+      {
+        "id": "10.6071",
+        "title": "10.6071",
+        "count": 1
+      },
+      {
+        "id": "10.1098",
+        "title": "10.1098",
+        "count": 1
+      }
+    ],
+    "citation-types": [
+      {
+        "id": "Collection-ScholarlyArticle",
+        "title": "Collection-ScholarlyArticle",
+        "count": 1,
+        "year-months": [
+          {
+            "id": "2019-03",
+            "title": "March 2019",
+            "sum": 1.0
+          }
+        ]
+      }
+    ],
+    "relation-types": [
+      {
+        "id": "is-supplement-to",
+        "title": "is-supplement-to",
+        "count": 1.0,
+        "year-months": [
+          {
+            "id": "2019-03",
+            "title": "March 2019",
+            "sum": 1.0
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "https://api.datacite.org/events?mailto=scott.fisher%40ucop.edu&page%5Bsize%5D=10000&subj-id=https%3A%2F%2Fdoi.org%2F10.6071%2Fm3rp49&relation-type-id=is-cited-by%2Cis-supplement-to%2Cis-described-by%2Cis-metadata-for%2Cis-referenced-by%2Cis-documented-by%2Cis-compiled-by%2Cis-reviewed-by%2Cis-derived-from%2Cis-required-by"
+  }
+}

--- a/stash_engine/spec/data/mdc-usage.json
+++ b/stash_engine/spec/data/mdc-usage.json
@@ -1,0 +1,125 @@
+{
+  "data": [],
+  "meta": {
+    "total": 19,
+    "total-pages": 0,
+    "page": 1,
+    "sources": [
+      {
+        "id": "datacite-usage",
+        "title": "DataCite Usage Stats",
+        "count": 19
+      }
+    ],
+    "prefixes": [
+      {
+        "id": "10.6071",
+        "title": "10.6071",
+        "count": 19
+      }
+    ],
+    "citation-types": [],
+    "relation-types": [
+      {
+        "id": "unique-dataset-investigations-regular",
+        "title": "unique-dataset-investigations-regular",
+        "count": 172.0,
+        "year-months": [
+          {
+            "id": "2018-04",
+            "title": "April 2018",
+            "sum": 16.0
+          },
+          {
+            "id": "2018-05",
+            "title": "May 2018",
+            "sum": 4.0
+          },
+          {
+            "id": "2018-06",
+            "title": "June 2018",
+            "sum": 18.0
+          },
+          {
+            "id": "2018-07",
+            "title": "July 2018",
+            "sum": 5.0
+          },
+          {
+            "id": "2018-08",
+            "title": "August 2018",
+            "sum": 16.0
+          },
+          {
+            "id": "2019-02",
+            "title": "February 2019",
+            "sum": 7.0
+          },
+          {
+            "id": "2019-03",
+            "title": "March 2019",
+            "sum": 12.0
+          },
+          {
+            "id": "2019-04",
+            "title": "April 2019",
+            "sum": 10.0
+          },
+          {
+            "id": "2019-05",
+            "title": "May 2019",
+            "sum": 24.0
+          },
+          {
+            "id": "2019-06",
+            "title": "June 2019",
+            "sum": 52.0
+          },
+          {
+            "id": "2019-07",
+            "title": "July 2019",
+            "sum": 8.0
+          }
+        ]
+      },
+      {
+        "id": "unique-dataset-requests-regular",
+        "title": "unique-dataset-requests-regular",
+        "count": 6.0,
+        "year-months": [
+          {
+            "id": "2018-04",
+            "title": "April 2018",
+            "sum": 4.0
+          },
+          {
+            "id": "2019-02",
+            "title": "February 2019",
+            "sum": 1.0
+          },
+          {
+            "id": "2019-07",
+            "title": "July 2019",
+            "sum": 1.0
+          }
+        ]
+      },
+      {
+        "id": "unique-dataset-investigations-machine",
+        "title": "unique-dataset-investigations-machine",
+        "count": 2.0,
+        "year-months": [
+          {
+            "id": "2018-08",
+            "title": "August 2018",
+            "sum": 2.0
+          }
+        ]
+      }
+    ]
+  },
+  "links": {
+    "self": "https://api.datacite.org/events?mailto=scott.fisher%40ucop.edu\u0026source-id=datacite-usage\u0026doi=10.6071%2Fm3rp49\u0026page%5Bsize%5D=0\u0026rows\u0026relation-type-id=unique-dataset-investigations-regular%2Cunique-dataset-investigations-machine%2Cunique-dataset-requests-regular%2Cunique-dataset-requests-machine",
+    "next": "https://api.datacite.org/events?doi=10.6071%2Fm3rp49\u0026page%5Bnumber%5D=2\u0026page%5Bsize%5D=0\u0026relation-type-id=unique-dataset-investigations-regular%2Cunique-dataset-investigations-machine%2Cunique-dataset-requests-regular%2Cunique-dataset-requests-machine\u0026source-id=datacite-usage"
+  }
+}

--- a/stash_engine/spec/unit/stash/event_data/citations_spec.rb
+++ b/stash_engine/spec/unit/stash/event_data/citations_spec.rb
@@ -9,7 +9,8 @@ module Stash
       before(:each) do
         @citations = Citations.new(doi: 'doi:10.6071/m3rp49')
         WebMock.disable_net_connect!
-        stub_request(:get, 'https://api.datacite.org/events?mailto=scott.fisher@ucop.edu&obj-id=https://doi.org/10.6071/m3rp49&page%5Bsize%5D=10000&relation-type-id=cites,describes,is-supplemented-by,references,compiles,reviews,requires,has-metadata,documents,is-source-of')
+        stub_request(:get, %r{https://api\.datacite\.org/events\?mailto=.+&obj-id=https://doi.org/10.6071/m3rp49&page%5Bsize%5D=10000
+            &relation-type-id=cites,describes,is-supplemented-by,references,compiles,reviews,requires,has-metadata,documents,is-source-of}x)
           .with(
             headers: {
               'Accept' => '*/*',
@@ -19,7 +20,9 @@ module Stash
           .to_return(status: 200, body: File.read(StashEngine::Engine.root.join('spec', 'data', 'event-data-citations1.json')),
                      headers: { 'Content-Type' => 'application/json' })
 
-        stub_request(:get, 'https://api.datacite.org/events?mailto=scott.fisher@ucop.edu&page%5Bsize%5D=10000&relation-type-id=is-cited-by,is-supplement-to,is-described-by,is-metadata-for,is-referenced-by,is-documented-by,is-compiled-by,is-reviewed-by,is-derived-from,is-required-by&subj-id=https://doi.org/10.6071/m3rp49')
+        stub_request(:get, %r{https://api\.datacite\.org/events\?mailto=.+&page%5Bsize%5D=10000&relation-type-id=is-cited-by,
+            is-supplement-to,is-described-by,is-metadata-for,is-referenced-by,is-documented-by,is-compiled-by,is-reviewed-by,
+            is-derived-from,is-required-by&subj-id=https://doi.org/10.6071/m3rp49}x)
           .with(
             headers: {
               'Accept' => '*/*',

--- a/stash_engine/spec/unit/stash/event_data/usage_spec.rb
+++ b/stash_engine/spec/unit/stash/event_data/usage_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'webmock/rspec'
-require 'byebug'
 
 module Stash
   module EventData
@@ -10,14 +9,15 @@ module Stash
         @usage = Usage.new(doi: 'doi:10.6071/m3rp49')
         WebMock.disable_net_connect!
 
-        stub_request(:get, 'https://api.datacite.org/events?doi=10.6071/m3rp49&mailto=scott.fisher@ucop.edu&page%5Bsize%5D=0&relation-type-id=unique-dataset-investigations-regular,unique-dataset-investigations-machine,unique-dataset-requests-regular,unique-dataset-requests-machine&rows&source-id=datacite-usage').
-            with(
-                headers: {
-                    'Accept'=>'*/*',
-                    'Host'=>'api.datacite.org'
-                }).
-            to_return(status: 200, body: File.read(StashEngine::Engine.root.join('spec', 'data', 'mdc-usage.json')),
-                      headers: {'Content-Type' => 'application/json'})
+        stub_request(:get, 'https://api.datacite.org/events?doi=10.6071/m3rp49&mailto=scott.fisher@ucop.edu&page%5Bsize%5D=0&relation-type-id=unique-dataset-investigations-regular,unique-dataset-investigations-machine,unique-dataset-requests-regular,unique-dataset-requests-machine&rows&source-id=datacite-usage')
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Host' => 'api.datacite.org'
+            }
+          )
+          .to_return(status: 200, body: File.read(StashEngine::Engine.root.join('spec', 'data', 'mdc-usage.json')),
+                     headers: { 'Content-Type' => 'application/json' })
       end
 
       describe :initializes do


### PR DESCRIPTION
see https://github.com/CDL-Dryad/dryad-product-roadmap/issues/273 .

I optimized the way we obtain counter stats so it is more efficient.  The main problem, though, was the crossref events service doesn't return results and times out.  We started using DataCite's event service.  Also set up to get only the kinds of citations Martin said.

You can check that they show up in the UI by going to https://dryad-dev.cdlib.org/stash/dataset/doi:10.6071/m3rp49 and looking at the metrics.  It's deployed to dev on the development branch.  This dataset had its doi changed to be one that has citations and usage for your viewing pleasure.