### PR TITLE
Journal peer review

### DIFF
--- a/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/resources/_review.html.erb
@@ -54,8 +54,9 @@
                   class: 'c-review-files-button o-button__icon-left', role: 'button' %>
     </div>
 
-  <% unless @resource.submitted? %>
-    <!-- This is only available if the version has not yet been submitted to the repository -->
+  <% if !@resource.submitted? && @resource.identifier.allow_review? %>
+    <!-- This is only available if the version has not yet been submitted to the repository AND
+    	 the associated journal allows a review workflow -->
     <h2 class="o-heading__page-span">Enable Private for Peer Review</h2>
       <div id="peer_review_section">
         <%= render partial: "stash_datacite/peer_review/review" %>

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -216,7 +216,7 @@ module StashEngine
     def publication_name
       publication_data('fullName')
     end
-    
+
     def journal_will_pay?
       plan_type = publication_data('paymentPlanType')
       plan_type == 'SUBSCRIPTION' ||
@@ -231,7 +231,7 @@ module StashEngine
     def allow_review?
       publication_data('allowReviewWorkflow') || publication_name.blank?
     end
-    
+
     def institution_will_pay?
       latest_resource&.tenant&.covers_dpc == true
     end

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -216,7 +216,7 @@ module StashEngine
     def publication_name
       publication_data('fullName')
     end
-
+    
     def journal_will_pay?
       plan_type = publication_data('paymentPlanType')
       plan_type == 'SUBSCRIPTION' ||
@@ -228,6 +228,10 @@ module StashEngine
       publication_data('stripeCustomerID')
     end
 
+    def allow_review?
+      publication_data('allowReviewWorkflow') || publication_name.blank?
+    end
+    
     def institution_will_pay?
       latest_resource&.tenant&.covers_dpc == true
     end

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -316,6 +316,26 @@ module StashEngine
       end
     end
 
+    describe '#journal_allows' do
+      it 'allows review when there is no journal' do
+        allow(@identifier).to receive('publication_name').and_return(nil)
+        allow(@identifier).to receive('publication_data').and_return(false)
+        expect(@identifier.allow_review?).to be(true)
+      end
+
+      it 'allows review when the journal allows review' do
+        allow(@identifier).to receive('publication_name').and_return('fakename')
+        allow(@identifier).to receive('publication_data').and_return(true)
+        expect(@identifier.allow_review?).to be(true)
+      end
+
+      it 'disallows review when the journal disallows review' do
+        allow(@identifier).to receive('publication_name').and_return('fakename')
+        allow(@identifier).to receive('publication_data').and_return(false)
+        expect(@identifier.allow_review?).to be(false)
+      end
+    end
+    
     describe '#journal_will_pay?' do
       it 'returns true when there is a PREPAID plan' do
         allow(@identifier).to receive('publication_data').and_return('PREPAID')
@@ -356,7 +376,7 @@ module StashEngine
         expect(@identifier.submitter_affiliation).to eql(@identifier.latest_resource&.authors&.first&.affiliation)
       end
     end
-
+    
     describe :with_visibility do
       before(:each) do
         Identifier.destroy_all

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -335,7 +335,7 @@ module StashEngine
         expect(@identifier.allow_review?).to be(false)
       end
     end
-    
+
     describe '#journal_will_pay?' do
       it 'returns true when there is a PREPAID plan' do
         allow(@identifier).to receive('publication_data').and_return('PREPAID')
@@ -376,7 +376,7 @@ module StashEngine
         expect(@identifier.submitter_affiliation).to eql(@identifier.latest_resource&.authors&.first&.affiliation)
       end
     end
-    
+
     describe :with_visibility do
       before(:each) do
         Identifier.destroy_all


### PR DESCRIPTION
Addresses https://github.com/CDL-Dryad/dryad-product-roadmap/issues/207

To test, create a submission and go to the review page. If the submission is associated with a journal that allows review, or if it is not associated with a journal, the "private for peer review" section will be displayed. If it is associated with a journal that does not allow review, the "private for peer review" section will not display.

Journals that *don't* allow peer review include:
- The American Naturalist
- BioMed Research International

Journals that *do* allow peer review include:
- American Journal of Botany
- Biology Letters