### PR TITLE
Added restriction to the default query behind the admin curation page

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -158,6 +158,7 @@ module StashEngine
       query_obj
     end
 
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
     def add_filters(query_obj:)
       # If no filters have been specified then auto filter by the following curation states to reduce the number
       # of records
@@ -180,6 +181,7 @@ module StashEngine
       end
       query_obj
     end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
     # this sets up the select list for internal data and will not offer options for items that are only allowed once and one is present
     def setup_internal_data_list

--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -159,6 +159,12 @@ module StashEngine
     end
 
     def add_filters(query_obj:)
+      # If no filters have been specified then auto filter by the following curation states to reduce the number
+      # of records
+      if params[:tenant].blank? && params[:curation_status].blank? && params[:publication_name].blank?
+        query_obj = query_obj.where(stash_engine_curation_activities: { status: %w[curation submitted action_required] })
+      end
+
       # Filter by Tenant
       if TENANT_IDS.include?(params[:tenant]) && current_user.role == 'superuser'
         query_obj = query_obj.where(stash_engine_resources: { tenant_id: params[:tenant] })

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -8,6 +8,8 @@
   <%= render partial: 'search' %>
   <%= render partial: 'filter' %>
 
+  <p>Note: if no filters are set above the list of datasets is restricted to ones with a status of 'Curation', 'Submitted' and 'Author Action Required'.</p>
+
   <%= render partial: 'datasets_table', locals: { resources: @resources } %>
 
   <div class="c-space-paginator">


### PR DESCRIPTION
This is a bandaid to address the Gateway timeouts we started seeing when loading the admin curation page on the fully migrated DB.

I restricted the default view to only include datasets who are in 'Curation', 'Submitted' or 'Author Action Required' states.

For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/412
