### PR TITLE
Move publication DOI from InternalDatum to RelatedIdentifier

### DIFF
--- a/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -8,11 +8,10 @@ module StashDatacite
       @metadata_entry = Resource::MetadataEntry.new(@resource, current_tenant)
       @metadata_entry.resource_type
       se_id = StashEngine::Identifier.find(@resource.identifier_id)
-      @publication = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'publicationISSN')
-      @msid = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
-      @doi = StashDatacite::RelatedIdentifier.find_or_create_by(resource_id: @resource.id, related_identifier_type: 'doi',
-                                                                relation_type: 'issupplementto')
-
+      @publication = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'publicationISSN')
+      @msid = StashEngine::InternalDatum.find_or_initialize_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
+      @doi = StashDatacite::RelatedIdentifier.find_or_initialize_by(resource_id: @resource.id, related_identifier_type: 'doi',
+                                                                    relation_type: 'issupplementto')
       respond_to do |format|
         format.js
       end

--- a/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/metadata_entry_pages_controller.rb
@@ -10,7 +10,8 @@ module StashDatacite
       se_id = StashEngine::Identifier.find(@resource.identifier_id)
       @publication = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'publicationISSN')
       @msid = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'manuscriptNumber')
-      @doi = StashEngine::InternalDatum.find_or_create_by(stash_identifier: se_id, data_type: 'publicationDOI')
+      @doi = StashDatacite::RelatedIdentifier.find_or_create_by(resource_id: @resource.id, related_identifier_type: 'doi',
+                                                                relation_type: 'issupplementto')
 
       respond_to do |format|
         format.js

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -20,7 +20,7 @@ module StashDatacite
             @resource = @se_id.latest_resource
             update_manuscript_metadata if params[:import_type] == 'manuscript'
             update_doi_metadata if !@doi&.related_identifier.blank? && params[:import_type] == 'published'
-            manage_pubmed_datum(identifier: @se_id, doi: @doi.value) if !@doi&.value.blank? && params[:import_type] == 'published'
+            manage_pubmed_datum(identifier: @se_id, doi: @doi.related_identifier) if !@doi&.related_identifier.blank? && params[:import_type] == 'published'
             params[:import_type] == 'published'
           else
             render template: 'stash_datacite/shared/update.js.erb'

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -20,7 +20,8 @@ module StashDatacite
             @resource = @se_id.latest_resource
             update_manuscript_metadata if params[:import_type] == 'manuscript'
             update_doi_metadata if !@doi&.related_identifier.blank? && params[:import_type] == 'published'
-            manage_pubmed_datum(identifier: @se_id, doi: @doi.related_identifier) if !@doi&.related_identifier.blank? && params[:import_type] == 'published'
+            manage_pubmed_datum(identifier: @se_id, doi: @doi.related_identifier) if !@doi&.related_identifier.blank? &&
+              params[:import_type] == 'published'
             params[:import_type] == 'published'
           else
             render template: 'stash_datacite/shared/update.js.erb'

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -7,7 +7,6 @@ require 'stash/link_out/pubmed_service'
 require 'cgi'
 
 module StashDatacite
-  # rubocop:disable Metrics/ClassLength
   class PublicationsController < ApplicationController
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
     def update
@@ -78,8 +77,8 @@ module StashDatacite
       if datum.present?
         datum.destroy unless value.present?
         datum.update(value: value) if value.present?
-      else
-        datum = StashEngine::InternalDatum.create(stash_identifier: identifier, data_type: data_type, value: value) if value.present?
+      elsif value.present?
+        datum = StashEngine::InternalDatum.create(stash_identifier: identifier, data_type: data_type, value: value)
       end
       datum
     end
@@ -120,5 +119,4 @@ module StashDatacite
     end
 
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -7,6 +7,7 @@ require 'stash/link_out/pubmed_service'
 require 'cgi'
 
 module StashDatacite
+  # rubocop:disable Metrics/ClassLength
   class PublicationsController < ApplicationController
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
     def update
@@ -134,4 +135,5 @@ module StashDatacite
     end
 
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -18,8 +18,9 @@ module StashDatacite
             @error = 'Please fill in the form completely' if params[:internal_datum][:msid].blank? && params[:internal_datum][:doi].blank?
             @resource = @se_id.latest_resource
             update_manuscript_metadata if params[:import_type] == 'manuscript'
-            update_doi_metadata if !@doi&.value.blank? && params[:import_type] == 'published'
+            update_doi_metadata if !@doi&.related_identifier.blank? && params[:import_type] == 'published'
             manage_pubmed_datum(identifier: @se_id, doi: @doi.value) if !@doi&.value.blank? && params[:import_type] == 'published'
+            params[:import_type] == 'published'
           else
             render template: 'stash_datacite/shared/update.js.erb'
           end
@@ -32,7 +33,8 @@ module StashDatacite
       @pub_issn = manage_internal_datum(identifier: @se_id, data_type: 'publicationISSN', value: params[:internal_datum][:publication_issn])
       @pub_name = manage_internal_datum(identifier: @se_id, data_type: 'publicationName', value: params[:internal_datum][:publication_name])
       @msid = manage_internal_datum(identifier: @se_id, data_type: 'manuscriptNumber', value: params[:internal_datum][:msid])
-      @doi = manage_internal_datum(identifier: @se_id, data_type: 'publicationDOI', value: params[:internal_datum][:doi])
+      @doi = manage_related_identifier(identifier: @se_id, related_identifier_type: 'doi', relation_type: 'issupplementto',
+                                       value: params[:internal_datum][:doi])
     end
 
     def update_manuscript_metadata
@@ -57,13 +59,13 @@ module StashDatacite
     end
 
     def update_doi_metadata
-      if @doi.value.blank?
+      if @doi.related_identifier.blank?
         @error = 'Please enter a DOI to import metadata'
         return
       end
-      cr = Stash::Import::Crossref.query_by_doi(resource: @resource, doi: @doi.value)
+      cr = Stash::Import::Crossref.query_by_doi(resource: @resource, doi: @doi.related_identifier)
       unless cr.present?
-        @error = "We couldn't obtain information from CrossRef about this DOI"
+        @error = "We couldn't obtain information from CrossRef about this DOI: #{@doi.related_identifier}"
         return
       end
       @resource = cr.populate_resource!
@@ -74,12 +76,26 @@ module StashDatacite
     def manage_internal_datum(identifier:, data_type:, value:)
       datum = StashEngine::InternalDatum.where(stash_identifier: identifier, data_type: data_type).first
       if datum.present?
-        datum.destroy if value.blank?
-        datum.update(value: value) unless value.blank?
+        datum.destroy unless value.present?
+        datum.update(value: value) if value.present?
       else
         datum = StashEngine::InternalDatum.create(stash_identifier: identifier, data_type: data_type, value: value)
       end
       datum
+    end
+
+    def manage_related_identifier(identifier:, related_identifier_type:, relation_type:, value:)
+      related_identifier = get_related_identifier(identifier: identifier, related_identifier_type: related_identifier_type,
+                                                  relation_type: relation_type)
+      if related_identifier.present?
+        related_identifier.destroy unless value.present?
+        related_identifier.update(related_identifier: value) if value.present?
+      else
+        related_identifier = StashDatacite::RelatedIdentifier.create(resource_id: @resource.id, relation_type: relation_type,
+                                                                     related_identifier_type: related_identifier_type,
+                                                                     related_identifier: value)
+      end
+      related_identifier
     end
 
     def manage_pubmed_datum(identifier:, doi:)
@@ -108,5 +124,14 @@ module StashDatacite
         external_ref.save
       end
     end
+
+    def get_related_identifier(identifier:, related_identifier_type:, relation_type:)
+      return nil unless identifier.present?
+      @resource = StashEngine::Identifier.find(identifier.is_a?(String) ? identifier : identifier.id).latest_resource
+      return nil unless @resource.present? && related_identifier_type.present? && relation_type.present?
+      StashDatacite::RelatedIdentifier.where(resource_id: @resource.id, relation_type: relation_type,
+                                             related_identifier_type: related_identifier_type).first
+    end
+
   end
 end

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_publication.html.erb
@@ -46,7 +46,7 @@
 			</div>
 			<div class="c-input js-doi-section">
 				<%= f.label "doi", 'DOI', class: 'c-input__label' %>
-				<%= f.text_field :doi, value: @doi.value, class: "js-doi c-input__text", placeholder: '5702.125/qlm.1266rr' %>
+				<%= f.text_field :doi, value: @doi.related_identifier, class: "js-doi c-input__text", placeholder: '5702.125/qlm.1266rr' %>
 			</div>
 		</div>
 		<div>
@@ -62,7 +62,7 @@
 </div>
 
 <script>
-	<% if !@doi&.value.blank? %>
+	<% if !@doi&.related_identifier.blank? %>
   	setPublicationChoiceDisplay('published');
 	<% elsif !@msid&.value.blank? %>
   	setPublicationChoiceDisplay('manuscript');

--- a/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash_datacite/lib/stash/import/crossref.rb
@@ -265,8 +265,9 @@ module Stash
       def populate_supplement_to
         return unless @sm['URL'].present? || @sm['DOI'].present?
         # Use the URL if available otherwise just use the DOI
-        @resource.related_identifiers.new(related_identifier: @sm['URL'] || @sm['DOI'], related_identifier_type: 'doi',
-                                          relation_type: 'issupplementto')
+        @resource.related_identifiers.find_or_initialize_by(related_identifier: @sm['URL'] || @sm['DOI'],
+                                                            related_identifier_type: 'doi',
+                                                            relation_type: 'issupplementto')
       end
 
       def populate_funders
@@ -274,11 +275,11 @@ module Stash
         @sm['funder'].each do |xr_funder|
           next if xr_funder['name'].blank?
           if xr_funder['award'].blank?
-            @resource.contributors.new(contributor_name: xr_funder['name'], contributor_type: 'funder')
+            @resource.contributors.find_or_initialize_by(contributor_name: xr_funder['name'], contributor_type: 'funder')
             next
           end
           xr_funder['award'].each do |xr_award|
-            @resource.contributors.new(contributor_name: xr_funder['name'], contributor_type: 'funder', award_number: xr_award)
+            @resource.contributors.find_or_initialize_by(contributor_name: xr_funder['name'], contributor_type: 'funder', award_number: xr_award)
           end
         end
       end

--- a/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash_datacite/lib/stash/import/crossref.rb
@@ -75,10 +75,9 @@ module Stash
         return unless @sm.present? && @resource.present?
         populate_abstract
         populate_authors
-        populate_cited_by
+        populate_supplement_to
         populate_funders
         populate_publication_date
-        populate_publication_doi
         populate_publication_issn
         populate_publication_name
         populate_title
@@ -95,6 +94,7 @@ module Stash
         params = {
           identifier_id: @resource.identifier.id,
           approved: false,
+          rejected: false,
           authors: @sm['author'].to_json,
           provenance: 'crossref',
           publication_date: date_parts_to_date(publication_date),
@@ -199,22 +199,30 @@ module Stash
 
       def resource_will_change?(proposed_change:)
         if proposed_change.authors.present?
-          auths = JSON.parse(proposed_change.authors).map do |auth|
-            StashEngine::Author.new(resource_id: @resource.id, author_orcid: auth['ORCID'],
-                                    author_first_name: auth['given'], author_last_name: auth['family'])
+          json = JSON.parse(proposed_change.authors)
+          if json.is_a?(Array) && json.any?
+            auths = json.map do |auth|
+              StashEngine::Author.new(resource_id: @resource.id, author_orcid: auth['ORCID'],
+                                      author_first_name: auth['given'], author_last_name: auth['family'])
+            end
           end
         end
 
         proposed_change.publication_date != @resource.publication_date ||
           internal_datum_will_change?(proposed_change: proposed_change) ||
+          related_identifier_will_change?(proposed_change: proposed_change) ||
           (proposed_change.authors.present? && (auths & @resource.authors).any?)
       end
 
       def internal_datum_will_change?(proposed_change:)
         internal_data = @resource.identifier.internal_data
         proposed_change.publication_name != internal_data.select { |d| d.data_type == 'publicationName' }.first&.value ||
-          proposed_change.publication_name != internal_data.select { |d| d.data_type == 'publicationISSN' }.first&.value ||
-          proposed_change.publication_name != internal_data.select { |d| d.data_type == 'publicationDOI' }.first&.value
+          proposed_change.publication_name != internal_data.select { |d| d.data_type == 'publicationISSN' }.first&.value
+      end
+
+      def related_identifier_will_change?(proposed_change:)
+        related_identifier = @resource.related_identifiers.where(related_identifier_type: 'doi', relation_type: 'issupplementto').first
+        proposed_change.publication_doi != related_identifier&.related_identifier
       end
 
       def populate_abstract
@@ -252,9 +260,11 @@ module Stash
         end
       end
 
-      def populate_cited_by
-        return unless @sm['URL'].present?
-        @resource.related_identifiers.new(related_identifier: @sm['URL'], related_identifier_type: 'doi', relation_type: 'iscitedby')
+      def populate_supplement_to
+        return unless @sm['URL'].present? || @sm['DOI'].present?
+        # Use the URL if available otherwise just use the DOI
+        @resource.related_identifiers.new(related_identifier: @sm['URL'] || @sm['DOI'], related_identifier_type: 'doi',
+                                          relation_type: 'issupplementto')
       end
 
       def populate_funders
@@ -274,13 +284,6 @@ module Stash
       def populate_publication_date
         return unless publication_date.present?
         @resource.publication_date = date_parts_to_date(publication_date)
-      end
-
-      def populate_publication_doi
-        return unless @sm['DOI'].present?
-        datum = StashEngine::InternalDatum.find_or_initialize_by(identifier_id: @resource.identifier.id,
-                                                                 data_type: 'publicationDOI')
-        datum.update(value: @sm['DOI'])
       end
 
       def populate_publication_issn

--- a/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash_datacite/lib/stash/import/crossref.rb
@@ -197,6 +197,7 @@ module Stash
         # rubocop:enable Metrics/PerceivedComplexity
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def resource_will_change?(proposed_change:)
         if proposed_change.authors.present?
           json = JSON.parse(proposed_change.authors)
@@ -213,6 +214,7 @@ module Stash
           related_identifier_will_change?(proposed_change: proposed_change) ||
           (proposed_change.authors.present? && (auths & @resource.authors).any?)
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def internal_datum_will_change?(proposed_change:)
         internal_data = @resource.identifier.internal_data

--- a/stash_datacite/lib/stash/indexer/indexing_resource.rb
+++ b/stash_datacite/lib/stash/indexer/indexing_resource.rb
@@ -217,8 +217,9 @@ module Stash
       end
 
       def related_publication_id
-        @resource.identifier.internal_data
-          .where(data_type: %w[manuscriptNumber publicationDOI pubmedID])&.map(&:value)&.join(' ')
+        ids = @resource.identifier.internal_data.where(data_type: %w[manuscriptNumber pubmedID])&.map(&:value)&.join(' ')
+        pub_doi = @resource.related_identifiers.where(related_identifier_type: 'doi', relation_type: 'issupplementto').first
+        (pub_doi.present? ? "#{ids} #{pub_doi.related_identifier}" : ids)
       end
 
       private

--- a/stash_datacite/lib/tasks/publication_updater.rake
+++ b/stash_datacite/lib/tasks/publication_updater.rake
@@ -22,14 +22,14 @@ namespace :publication_updater do
       next if resource.curation_activities.where('stash_engine_curation_activities.note LIKE ?',
                                                  "%#{StashEngine::ProposedChange::CROSSREF_UPDATE_MESSAGE}").any?
 
-      doi = resource.identifier.internal_data.where(data_type: 'publicationDOI').first
+      doi = resource.related_identifiers.where(relation_type: 'issupplementto', related_identifier_type: 'doi').first
 
       begin
-        cr = Stash::Import::Crossref.query_by_doi(resource: resource, doi: doi.value) if doi.present?
+        cr = Stash::Import::Crossref.query_by_doi(resource: resource, doi: doi.related_identifier) if doi.present?
         cr = Stash::Import::Crossref.query_by_author_title(resource: resource) unless cr.present?
       rescue URI::InvalidURIError => iue
         # If the URI is invalid, just skip to the next record
-        p "ERROR querying Crossref for '#{doi.value}' : #{iue.message}"
+        p "ERROR querying Crossref for publication DOI: '#{doi&.related_identifier}' for identifier: '#{resource.identifier}' : #{iue.message}"
         next
       end
 

--- a/stash_datacite/lib/tasks/stash_datacite_tasks.rake
+++ b/stash_datacite/lib/tasks/stash_datacite_tasks.rake
@@ -1,4 +1,25 @@
-# desc "Explaining what the task does"
-# task :stash_datacite do
-#   # Task goes here
-# end
+require 'stash/import/crossref'
+
+namespace :stash_datacite do
+
+  desc 'Convert old publicationDOI records from InternalDatum into RelatedIdentifiers'
+  task internal_data_to_related_identifier: :environment do
+    StashEngine::InternalDatum.joins(stash_identifier: :resources)
+      .includes(stash_identifier: :resources)
+      .where(data_type: 'publicationDOI').each do |internal_datum|
+      next unless internal_datum.value.present?
+
+      resource = internal_datum.stash_identifier.latest_resource
+      next unless resource.present?
+
+      related_identifier = StashDatacite::RelatedIdentifier.find_or_create_by(resource_id: resource.id,
+                                                                              related_identifier_type: 'doi', relation_type: 'issupplementto')
+
+      # Only overwrite the value if its blank!
+      related_identifier.update(related_identifier: internal_datum.value) unless related_identifier.related_identifier.present?
+
+    end
+    StashEngine::InternalDatum.where(data_type: 'publicationDOI').destroy_all
+  end
+
+end

--- a/stash_datacite/spec/db/stash_datacite/author_spec.rb
+++ b/stash_datacite/spec/db/stash_datacite/author_spec.rb
@@ -19,10 +19,10 @@ module StashEngine # TODO: are we testing Author or Affiliation? (Or AuthorPatch
 
     describe 'scopes' do
       describe :affiliation_filled do
-        it 'includes affiliations w/short name'
-        it 'includes affiliations w/long name'
-        it 'includes affiliations w/both'
-        it 'excludes affiliations w/neither'
+        xit 'includes affiliations w/short name'
+        xit 'includes affiliations w/long name'
+        xit 'includes affiliations w/both'
+        xit 'excludes affiliations w/neither'
       end
     end
 

--- a/stash_datacite/spec/db/stash_engine/proposed_change_spec.rb
+++ b/stash_datacite/spec/db/stash_engine/proposed_change_spec.rb
@@ -103,9 +103,9 @@ module StashEngine
         expect(@resource.authors.first.author_first_name).to eql(auths.first['given'])
         expect(@resource.authors.first.author_last_name).to eql(auths.first['family'])
         expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(@params[:publication_name])
-        expect(@resource.related_identifiers.select { |id|
+        expect(@resource.related_identifiers.select do |id|
           id.related_identifier_type == 'doi' && id.relation_type == 'issupplementto'
-        }.first&.related_identifier).to eql(@params[:publication_doi])
+        end.first&.related_identifier).to eql(@params[:publication_doi])
 
         expect(@resource.publication_date.to_date).to eql(@params[:publication_date])
 

--- a/stash_datacite/spec/db/stash_engine/proposed_change_spec.rb
+++ b/stash_datacite/spec/db/stash_engine/proposed_change_spec.rb
@@ -103,7 +103,10 @@ module StashEngine
         expect(@resource.authors.first.author_first_name).to eql(auths.first['given'])
         expect(@resource.authors.first.author_last_name).to eql(auths.first['family'])
         expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(@params[:publication_name])
-        expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationDOI' }.first.value).to eql(@params[:publication_doi])
+        expect(@resource.related_identifiers.select { |id|
+          id.related_identifier_type == 'doi' && id.relation_type == 'issupplementto'
+        }.first&.related_identifier).to eql(@params[:publication_doi])
+
         expect(@resource.publication_date.to_date).to eql(@params[:publication_date])
 
         @proposed_change.reload

--- a/stash_datacite/spec/unit/stash/import/crossref_spec.rb
+++ b/stash_datacite/spec/unit/stash/import/crossref_spec.rb
@@ -385,7 +385,7 @@ module Stash
           expect(@resource.related_identifiers.first.related_identifier).to eql(URL)
           expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(PUBLISHER)
           doi = @resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'issupplementto' }
-          expect(doi.first&.related_identifier).to eql(DOI)
+          expect(doi.first&.related_identifier).to end_with(DOI)
           expect(@resource.publication_date.strftime('%Y-%m-%d')).to eql(@cr.send(:date_parts_to_date, PAST_PUBLICATION_DATE).to_s)
         end
       end

--- a/stash_datacite/spec/unit/stash/import/crossref_spec.rb
+++ b/stash_datacite/spec/unit/stash/import/crossref_spec.rb
@@ -273,40 +273,22 @@ module Stash
         end
       end
 
-      describe '#populate_cited_by' do
+      describe '#populate_supplement_to' do
         before(:each) do
           @cr = Crossref.new(resource: @resource, crossref_json: { 'URL' => URL })
         end
 
-        it 'takes the DOI URL for the article and turns it into cited_by for this dataset' do
-          @cr.send(:populate_cited_by)
+        it 'takes the DOI URL for the article and turns it into is_supplement_to for this dataset' do
+          @cr.send(:populate_supplement_to)
           expect(@resource.related_identifiers.any?).to eql(true)
           expect(@resource.related_identifiers.first.related_identifier).to eql(URL)
         end
 
         it 'ignores blank URLs' do
           @cr = Crossref.new(resource: @resource, crossref_json: { 'URL' => '' })
-          resp = @cr.send(:populate_cited_by)
+          resp = @cr.send(:populate_supplement_to)
           expect(resp).to eql(nil)
           expect(@resource.related_identifiers.length).to eql(0)
-        end
-      end
-
-      describe '#populate_doi' do
-        before(:each) do
-          @cr = Crossref.new(resource: @resource, crossref_json: { 'DOI' => DOI })
-        end
-
-        it 'adds the publicationDOI to Internal Datum' do
-          @cr.send(:populate_publication_doi)
-          expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationDOI' }.first.value).to eql(DOI)
-        end
-
-        it 'ignores blank DOIs' do
-          @cr = Crossref.new(resource: @resource, crossref_json: { 'DOI' => nil })
-          resp = @cr.send(:populate_publication_doi)
-          expect(resp).to eql(nil)
-          expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationDOI' }.empty?).to eql(true)
         end
       end
 
@@ -402,7 +384,8 @@ module Stash
           expect(@resource.contributors.length).to eql(11)
           expect(@resource.related_identifiers.first.related_identifier).to eql(URL)
           expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(PUBLISHER)
-          expect(@resource.identifier.internal_data.select { |id| id.data_type == 'publicationDOI' }.first.value).to eql(DOI)
+          doi = @resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'issupplementto' }
+          expect(doi.first&.related_identifier).to eql(DOI)
           expect(@resource.publication_date.strftime('%Y-%m-%d')).to eql(@cr.send(:date_parts_to_date, PAST_PUBLICATION_DATE).to_s)
         end
       end
@@ -641,11 +624,11 @@ module Stash
           auths = JSON.parse(@params[:authors])
           expect(resource.title).to eql(@params[:title])
           expect(resource.identifier.internal_data.select { |id| id.data_type == 'publicationName' }.first.value).to eql(@params[:publication_name])
-          expect(resource.identifier.internal_data.select { |id| id.data_type == 'publicationDOI' }.first.value).to eql(@params[:publication_doi])
           expect(resource.publication_date.strftime('%Y-%m-%d')).to eql(@params[:publication_date].to_s)
           expect(resource.authors.first.author_first_name).to eql(auths.first['given'])
           expect(resource.authors.first.author_last_name).to eql(auths.first['family'])
-
+          doi = resource.related_identifiers.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'issupplementto' }
+          expect(doi.first&.related_identifier).to eql(@params[:publication_doi])
         end
       end
 

--- a/stash_datacite/spec/unit/stash/indexer/indexing_resource_spec.rb
+++ b/stash_datacite/spec/unit/stash/indexer/indexing_resource_spec.rb
@@ -52,9 +52,14 @@ module Stash
         @user = create(:user)
         @identifier = create(:identifier)
         @internal_data = create(:internal_data, identifier_id: @identifier.id)
+        create(:internal_data, identifier_id: @identifier.id, data_type: 'manuscriptNumber', value: 'manuscript123')
+        create(:internal_data, identifier_id: @identifier.id, data_type: 'pubmedID', value: 'pubmed123')
+        create(:internal_data, identifier_id: @identifier.id, data_type: 'mismatchedDOI', value: 'doi987')
         @resource = create(:resource, identifier_id: @identifier.id, user_id: @user.id)
         @resource_state = create(:resource_state, resource_id: @resource.id)
         @resource.update(current_resource_state_id: @resource_state.id)
+        create(:related_identifier, resource_id: @resource.id, related_identifier_type: 'doi', relation_type: 'issupplementto',
+                                    related_identifier: 'doi123')
         @version = create(:version, resource_id: @resource.id)
         @affil1 = create(:affiliation, long_name: 'Lafayette Tech')
         @affil2 = create(:affiliation, long_name: 'Orinda Tech')
@@ -286,7 +291,7 @@ module Stash
             dc_publisher_s: 'Dryad',
             dct_temporal_sm: ['2018-11-14'],
             dryad_related_publication_name_s: 'Journal of Testing Fun',
-            dryad_related_publication_id_s: ''
+            dryad_related_publication_id_s: 'manuscript123 pubmed123 doi123'
           }
           expect(mega_hash).to eql(expected_mega_hash)
         end

--- a/stash_engine/app/controllers/stash_engine/widgets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/widgets_controller.rb
@@ -38,9 +38,11 @@ module StashEngine
     end
 
     def require_id_exists
-      pmid_record = InternalDatum.find_by(data_type: 'pubmedID', value: @pmid) ||
-          InternalDatum.find_by(data_type: 'publicationDOI', value: @doi)
-      @stash_id = pmid_record.stash_identifier unless pmid_record.blank?
+      pmid = InternalDatum.find_by(data_type: 'pubmedID', value: @pmid)
+      doi = StashDatacite::RelatedIdentifier.find_by(related_identifier_type: 'doi', relation_type: 'issupplementto',
+                                                     related_identifier: @doi)
+      @stash_id = pmid.stash_identifier unless pmid.blank?
+      @stash_id = doi.resource.identifier if @stash_id.blank? && doi.present?
       not_found if @stash_id.blank?
     end
 

--- a/stash_engine/app/helpers/stash_engine/link_generator.rb
+++ b/stash_engine/app/helpers/stash_engine/link_generator.rb
@@ -121,7 +121,7 @@ module StashEngine
           @id_value[@target_prefix.strip.length..-1].strip
         else
           # they must've given it as a bare id if it didn't have the prefix (and isn't a URL)
-          @id_value.strip
+          @id_value&.strip
         end
       end
 

--- a/stash_engine/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/stash_engine/app/helpers/stash_engine/publication_updater_helper.rb
@@ -26,6 +26,12 @@ module StashEngine
       resource.identifier.internal_data.where(data_type: data_type).first&.value || 'Not available'
     end
 
+    def fetch_related_identifier_metadata(resource:, related_identifier_type:, relation_type:)
+      return nil unless resource.present? && related_identifier_type.present? && relation_type.present?
+      resource.related_identifiers.where(related_identifier_type: related_identifier_type,
+                                         relation_type: relation_type).first&.value || 'Not available'
+    end
+
     def existing_authors(resource:)
       return nil unless resource.present?
       resource.authors.map(&:author_full_name).uniq.sort { |a, b| a <=> b }.join('<br>')

--- a/stash_engine/app/models/stash_engine/internal_datum.rb
+++ b/stash_engine/app/models/stash_engine/internal_datum.rb
@@ -3,7 +3,7 @@ module StashEngine
     belongs_to :stash_identifier, class_name: 'StashEngine::Identifier', foreign_key: 'identifier_id'
     validates :data_type, inclusion: {
       in: %w[manuscriptNumber mismatchedDOI duplicateItem formerManuscriptNumber publicationISSN
-             publicationName publicationDOI pubmedID dansArchiveDate dansEditIRI],
+             publicationName pubmedID dansArchiveDate dansEditIRI],
       message: '%{value} is not a valid data type'
     }
     validates :data_type, presence: true
@@ -15,7 +15,7 @@ module StashEngine
 
     def self.allows_multiple(type)
       case type
-      when 'publicationName', 'manuscriptNumber', 'publicationISSN', 'publicationDOI', 'pubmedID', 'dansArchiveDate', 'dansEditIRI'
+      when 'publicationName', 'manuscriptNumber', 'publicationISSN', 'pubmedID', 'dansArchiveDate', 'dansEditIRI'
         false
       when 'mismatchedDOI', 'duplicateItem', 'formerManuscriptNumber'
         true

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -620,14 +620,8 @@ module StashEngine
     # -----------------------------------------------------------
     # Determines whether the resource needs to go through a peer review
     def requires_peer_review?
-      # return false if this is NOT the first version
-      return false if identifier.blank? || identifier.resources.length > 1
-
-      # TODO: @ryscher, we need to first use the `hold_for_peer_review` flag since it is set by
-      #       the user when submitting their dataset. If the flag has not been set by the user then
-      #       we need to swap out this `internal_data` check with a call to the old Dryad service
-      #       that correctly indicates whether the associated journal should enter peer_review status
-      hold_for_peer_review? || identifier&.internal_data&.where(data_type: %w[publicationISSN publicationDOI manuscriptNumber])&.any?
+      # If this is the first version and the user opted to hold for peer review
+      identifier.present? && identifier.resources.length == 1 && hold_for_peer_review?
     end
 
   end

--- a/stash_engine/app/services/stash_engine/status_dashboard/oai_service.rb
+++ b/stash_engine/app/services/stash_engine/status_dashboard/oai_service.rb
@@ -9,11 +9,8 @@ module StashEngine
 
       def ping_dependency
         super
-        timeframe = (Time.now - 5.minutes).utc.strftime('%y-%m-%dT%H:%M:%SZ')
         env = Rails.env.production? ? 'prd' : 'stg'
-        base_url = "http://uc3-mrtoai-#{env}.cdlib.org:37001/mrtoai/oai/v2"
-        target = "#{base_url}?verb=ListRecords&metadataPrefix=dcs3.1&from=#{timeframe}"
-
+        target = "http://uc3-mrtoai-#{env}.cdlib.org:37001/mrtoai/state"
         resp = HTTParty.get(target)
         online = resp.code == 200
         msg = resp.body unless online

--- a/stash_engine/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
+++ b/stash_engine/app/views/stash_engine/publication_updater/_proposed_change_line.html.erb
@@ -1,7 +1,8 @@
 <%
   existing_pubname = fetch_identifier_metadata(resource: resource, data_type: 'publicationName')
   existing_pubissn = fetch_identifier_metadata(resource: resource, data_type: 'publicationISSN')
-  existing_pubdoi = fetch_identifier_metadata(resource: resource, data_type: 'publicationDOI')
+  existing_pubdoi = fetch_related_identifier_metadata(resource: resource, related_identifier_type: 'doi',
+                                                      relation_type: 'issupplementto')
 %>
 <tr class="c-lined-table__row" id="current_<%= proposed_change.id %>">
   <%= render partial: 'current_metadata', locals: { resource: resource, existing_pubdoi: existing_pubdoi, existing_pubissn: existing_pubissn, existing_pubname: existing_pubname } %>

--- a/stash_engine/lib/tasks/link_out.rake
+++ b/stash_engine/lib/tasks/link_out.rake
@@ -114,13 +114,13 @@ namespace :link_out do
     p 'Updating Solr keywords with manuscriptNumber, pubmedID or a isSupplementTo related identifier'
     types = %w[pubmedID manuscriptNumber]
 
-     StashEngine::Identifier.all.each do |identifier|
+    StashEngine::Identifier.all.each do |identifier|
       datum = identifier.joins(:internal_data, resource: :related_identifiers)
         .where('(stash_engine_internal_data.data_type IN (?) AND stash_engine_internal_data.value IS NOT NULL) \
           OR (dcs_related_identifiers.related_identifier_type = ? AND dcs_related_identifiers.relation_type = ? AND \
               dcs_related_identifiers.related_identifier IS NOT NULL)', types, 'doi', 'issupplementto')
 
-       if datum.any?
+      if datum.any?
         identifier.update_search_words!
         identifier.latest_resource.submit_to_solr
       end

--- a/stash_engine/spec/db/stash_engine/internal_datum_spec.rb
+++ b/stash_engine/spec/db/stash_engine/internal_datum_spec.rb
@@ -1,0 +1,75 @@
+require 'ostruct'
+require_relative '../../../../spec_helpers/factory_helper'
+require 'byebug'
+
+ module StashEngine
+  RSpec.describe InternalDatum do
+
+     before(:each) do
+      @identifier = create(:identifier)
+      @resource = create(:resource, identifier_id: @identifier.id)
+    end
+
+     context 'class methods' do
+
+       describe :data_type do
+
+         before(:each) do
+          @doi = create(:internal_datum, identifier_id: @identifier.id, data_type: 'manuscriptNumber', value: '10.123/ABC123.567')
+          @name1 = create(:internal_datum, identifier_id: @identifier.id, data_type: 'publicationName', value: 'Mad Magazine')
+          @name2 = create(:internal_datum, identifier_id: @identifier.id, data_type: 'publicationName', value: 'Cracked')
+        end
+
+         it 'returns the correct records' do
+          expect(StashEngine::InternalDatum.data_type('manuscriptNumber').length).to eql(1)
+          expect(StashEngine::InternalDatum.data_type('publicationName').length).to eql(2)
+        end
+
+         it 'returns an empty collection if no records were matched' do
+          expect(StashEngine::InternalDatum.data_type(nil).length).to eql(0)
+          expect(StashEngine::InternalDatum.data_type('mismatchedDOI').length).to eql(0)
+          expect(StashEngine::InternalDatum.data_type('u45hy945hg9ui').length).to eql(0)
+        end
+
+       end
+
+       describe :allows_multiple do
+
+         it 'returns true if the data_type is mismatchedDOI' do
+          expect(StashEngine::InternalDatum.allows_multiple('mismatchedDOI')).to eq(true)
+        end
+        it 'returns true if the data_type is mismatchedDOI' do
+          expect(StashEngine::InternalDatum.allows_multiple('duplicateItem')).to eq(true)
+        end
+        it 'returns true if the data_type is mismatchedDOI' do
+          expect(StashEngine::InternalDatum.allows_multiple('formerManuscriptNumber')).to eq(true)
+        end
+
+         it 'returns false if the data_type is publicationName' do
+          expect(StashEngine::InternalDatum.allows_multiple('publicationName')).to eq(false)
+        end
+        it 'returns false if the data_type is manuscriptNumber' do
+          expect(StashEngine::InternalDatum.allows_multiple('manuscriptNumber')).to eq(false)
+        end
+        it 'returns false if the data_type is publicationISSN' do
+          expect(StashEngine::InternalDatum.allows_multiple('publicationISSN')).to eq(false)
+        end
+        it 'returns false if the data_type is pubmedID' do
+          expect(StashEngine::InternalDatum.allows_multiple('pubmedID')).to eq(false)
+        end
+        it 'returns false if the data_type is dansArchiveDate' do
+          expect(StashEngine::InternalDatum.allows_multiple('dansArchiveDate')).to eq(false)
+        end
+        it 'returns false if the data_type is dansEditIRI' do
+          expect(StashEngine::InternalDatum.allows_multiple('dansEditIRI')).to eq(false)
+        end
+
+         it 'returns false if the data_type is unknown' do
+          expect(StashEngine::InternalDatum.allows_multiple('ejhirgiq3gi')).to eq(false)
+          expect(StashEngine::InternalDatum.allows_multiple(nil)).to eq(false)
+        end
+      end
+    end
+
+   end
+end

--- a/stash_engine/spec/db/stash_engine/internal_datum_spec.rb
+++ b/stash_engine/spec/db/stash_engine/internal_datum_spec.rb
@@ -2,40 +2,40 @@ require 'ostruct'
 require_relative '../../../../spec_helpers/factory_helper'
 require 'byebug'
 
- module StashEngine
+module StashEngine
   RSpec.describe InternalDatum do
 
-     before(:each) do
+    before(:each) do
       @identifier = create(:identifier)
       @resource = create(:resource, identifier_id: @identifier.id)
     end
 
-     context 'class methods' do
+    context 'class methods' do
 
-       describe :data_type do
+      describe :data_type do
 
-         before(:each) do
+        before(:each) do
           @doi = create(:internal_datum, identifier_id: @identifier.id, data_type: 'manuscriptNumber', value: '10.123/ABC123.567')
           @name1 = create(:internal_datum, identifier_id: @identifier.id, data_type: 'publicationName', value: 'Mad Magazine')
           @name2 = create(:internal_datum, identifier_id: @identifier.id, data_type: 'publicationName', value: 'Cracked')
         end
 
-         it 'returns the correct records' do
+        it 'returns the correct records' do
           expect(StashEngine::InternalDatum.data_type('manuscriptNumber').length).to eql(1)
           expect(StashEngine::InternalDatum.data_type('publicationName').length).to eql(2)
         end
 
-         it 'returns an empty collection if no records were matched' do
+        it 'returns an empty collection if no records were matched' do
           expect(StashEngine::InternalDatum.data_type(nil).length).to eql(0)
           expect(StashEngine::InternalDatum.data_type('mismatchedDOI').length).to eql(0)
           expect(StashEngine::InternalDatum.data_type('u45hy945hg9ui').length).to eql(0)
         end
 
-       end
+      end
 
-       describe :allows_multiple do
+      describe :allows_multiple do
 
-         it 'returns true if the data_type is mismatchedDOI' do
+        it 'returns true if the data_type is mismatchedDOI' do
           expect(StashEngine::InternalDatum.allows_multiple('mismatchedDOI')).to eq(true)
         end
         it 'returns true if the data_type is mismatchedDOI' do
@@ -45,7 +45,7 @@ require 'byebug'
           expect(StashEngine::InternalDatum.allows_multiple('formerManuscriptNumber')).to eq(true)
         end
 
-         it 'returns false if the data_type is publicationName' do
+        it 'returns false if the data_type is publicationName' do
           expect(StashEngine::InternalDatum.allows_multiple('publicationName')).to eq(false)
         end
         it 'returns false if the data_type is manuscriptNumber' do
@@ -64,12 +64,12 @@ require 'byebug'
           expect(StashEngine::InternalDatum.allows_multiple('dansEditIRI')).to eq(false)
         end
 
-         it 'returns false if the data_type is unknown' do
+        it 'returns false if the data_type is unknown' do
           expect(StashEngine::InternalDatum.allows_multiple('ejhirgiq3gi')).to eq(false)
           expect(StashEngine::InternalDatum.allows_multiple(nil)).to eq(false)
         end
       end
     end
 
-   end
+  end
 end


### PR DESCRIPTION
Moved the publication DOI data from `stash_engine_internal_data` to `dcs_related_identifiers`

For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/303

This also includes an update to the Publication Updater's OAI check to use a different URL per the Merritt team's request