### PR TITLE
Allow API to find datasets by manuscript number

### DIFF
--- a/stash_api/app/controllers/stash_api/datasets_controller.rb
+++ b/stash_api/app/controllers/stash_api/datasets_controller.rb
@@ -50,12 +50,18 @@ module StashApi
       # We probably want to think about the query interface before we do full blown filtering and be sure it is thought out
       # and we are ready to support whatever we decide.
 
-      # if a publicationISSN is specified, we want to make sure that we're only working those specified.
+      # if a publicationISSN or manuscriptNumber is specified,
+      # we want to make sure that we're only working those specified.
       if params.key?('publicationISSN')
         # add these conditions to narrow to publicationISSN
         ds_query = ds_query
           .joins('INNER JOIN stash_engine_internal_data ON stash_engine_identifiers.id = stash_engine_internal_data.identifier_id')
           .where("stash_engine_internal_data.data_type = 'publicationISSN' AND stash_engine_internal_data.value = ?", params['publicationISSN'])
+      elsif params.key?('manuscriptNumber')
+        # add these conditions to narrow to manuscriptNumber
+        ds_query = ds_query
+          .joins('INNER JOIN stash_engine_internal_data ON stash_engine_identifiers.id = stash_engine_internal_data.identifier_id')
+          .where("stash_engine_internal_data.data_type = 'manuscriptNumber' AND stash_engine_internal_data.value = ?", params['manuscriptNumber'])
       end
 
       # now, if a curationStatus is specified, narrow down the previous result more.


### PR DESCRIPTION
To support https://github.com/CDL-Dryad/dryad-product-roadmap/issues/236, allow selection of a dataset by manuscriptNumber. Note that the `publicationISSN` and `manuscriptNumber` may not be specified at the same time. 

To test, ensure  an dataset contains the target manuscript number, then make a GET call like: 
`curl -i -X GET http://ryandash.datadryad.org/api/datasets?manuscriptNumber=JAMIO-2017-0039.R2 -H "Authorization: Bearer 0dd1ce438bfb00c5101c466f6e3fc2a9cd4862f2495ce62953cbfb6d7ef10c74" -H "Content-Type: application/json" `