### PR TITLE
fixed issue where new patch that pre-filters curation page data was o…

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -162,7 +162,7 @@ module StashEngine
     def add_filters(query_obj:)
       # If no filters have been specified then auto filter by the following curation states to reduce the number
       # of records
-      if params[:tenant].blank? && params[:curation_status].blank? && params[:publication_name].blank?
+      if params[:tenant].blank? && params[:curation_status].blank? && params[:publication_name].blank? && params[:q].blank?
         query_obj = query_obj.where(stash_engine_curation_activities: { status: %w[curation submitted action_required] })
       end
 


### PR DESCRIPTION
the patch that we added to pre-filter the curation page (submitted, curation and author_action) was overriding any search criteria that the user entered. 

To replicate the issue, find a search term for a published/embargoed dataset, remove all filters so that you are only seeing submitted/curation/author_action records. Then enter the search term.