### PR TITLE
Fix external dependency status checks

### DIFF
--- a/stash_engine/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
+++ b/stash_engine/app/services/stash_engine/status_dashboard/dependency_checker_service.rb
@@ -5,6 +5,8 @@ module StashEngine
 
     class DependencyCheckerService
 
+      DATE_TIME_MATCHER = /[0-9]{4}\-[0-9]{2}\-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}/
+
       def initialize(**args)
         @dependency = StashEngine::ExternalDependency.find_by(abbreviation: args[:abbreviation])
       end
@@ -26,6 +28,12 @@ module StashEngine
 
       def report_outage
         UserMailer.dependency_offline(@dependency).deliver_now
+      end
+
+      def extract_last_log_date(log)
+        contents = File.open(log).to_a
+        last_run_date = Time.parse(line.match(DATE_TIME_MATCHER).to_s) unless contents.empty?
+        last_run_date
       end
 
     end

--- a/stash_engine/app/services/stash_engine/status_dashboard/download_service.rb
+++ b/stash_engine/app/services/stash_engine/status_dashboard/download_service.rb
@@ -18,7 +18,8 @@ module StashEngine
         client = Stash::Repo::HttpClient.new(tenant: resource.tenant, cert_file: APP_CONFIG.ssl_cert_file).client
         resp = client.head(resource.download_uri, follow_redirect: true)
         online = resp.code == 200
-        msg = resp.body unless online
+        msg = "Merritt Download service is reporting an HTTP #{resp.code}!" unless online
+        msg += resp.body if !online && resp.body.present?
         record_status(online: online, message: msg)
         online
       rescue StandardError => e

--- a/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
+++ b/stash_engine/app/services/stash_engine/status_dashboard/notifier_service.rb
@@ -7,21 +7,16 @@ module StashEngine
 
     class NotifierService < DependencyCheckerService
 
-      LOG_FILE = '/dryad/apps/ui/shared/cron/logs/stash-notifier.log'.freeze
-      DATE_TIME_MATCHER = /[0-9]{4}\-[0-9]{2}\-[0-9]{2}T([0-9]{2}:){2}[0-9]{2}/.freeze
+      LOG_FILE = '/dryad/apps/ui/shared/cron/logs/stash-notifier.log'
 
       def ping_dependency
         super
         record_status(online: false, message: "No log file found at '#{LOG_FILE}'.") unless File.exist?(LOG_FILE)
         return false unless File.exist?(LOG_FILE)
 
-        online = true
-        contents = File.open(LOG_FILE).to_a
-        online = false if contents.empty?
-        last_run_date = Time.parse(line.match(DATE_TIME_MATCHER).to_s) if online
-        online = last_run_date >= (Time.now - 15.minutes)
-        msg = "The Notifier service has not updated its log since #{last_run_date}." if !online && last_run_date.present?
-        msg = "The Notifier service has an empty log." if !online && !last_run_date.present?
+        last_run_date = extract_last_log_date(LOG_FILE)
+        online = last_run_date.present? && last_run_date >= (Time.now - 15.minutes)
+        msg = "The Notifier service has not updated its log since '#{last_run_date}'." unless online
         record_status(online: online, message: msg)
         online
       rescue StandardError => e


### PR DESCRIPTION
This addresses some of the issues we've been seeing with the status dashboard checks: ticket https://github.com/CDL-Dryad/dryad-product-roadmap/issues/414

- The OAI feed issue was resolved in a prior PR ... we updated the URL we were pinging.
- The Merritt download service has been reporting a 401 on the stage instance. I have updated the code to provide more information for us on the dashboard (basically the HTTP status) to help us debug. I think this may be a legit issue, it uses the following line, `client = Stash::Repo::HttpClient.new(tenant: resource.tenant, cert_file: APP_CONFIG.ssl_cert_file).client`, which references an SSL cert, so maybe something we need to update in the config files for the new linux2 servers
- Updated the Notifier service check to examine its cron log and report an outage if it hasn't run in the past 15 minutes.