### PR TITLE
Some minor static content changes

### DIFF
--- a/stash_engine/app/views/stash_engine/pages/_nav.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/_nav.html.erb
@@ -38,7 +38,7 @@
             <%= link_to 'Our Mission', "#{stash_url_helpers.our_mission_path}", class: 'o-sites__group-item' %>
             <%= link_to 'Our Community', "#{stash_url_helpers.our_community_path}", class: 'o-sites__group-item' %>
             <%= link_to 'Our Governance', "#{stash_url_helpers.our_governance_path}", class: 'o-sites__group-item' %>
-            <%= link_to 'Our Staff', "#{stash_url_helpers.our_staff_path}", class: 'o-sites__group-item' %>
+            <%= link_to 'Our Team', "#{stash_url_helpers.our_staff_path}", class: 'o-sites__group-item' %>
             <%= link_to 'Our Platform', "#{stash_url_helpers.our_platform_path}", class: 'o-sites__group-item' %>
           </div>
         </details>
@@ -50,11 +50,10 @@
         <details class="o-showhide o-sites__details" role="group">
           <summary class="o-showhide__summary o-sites__summary">Help</summary>
           <div class="o-sites__group">
-            <%= link_to 'Why Use Dryad?', "#{stash_url_helpers.why_use_path}", class: 'o-sites__group-item' %>
             <%= link_to 'Submission Process', "#{stash_url_helpers.submission_process_path}", class: 'o-sites__group-item' %>
             <%= link_to 'Curation', "#{stash_url_helpers.submission_process_path(anchor: 'curation')}", class: 'o-sites__group-item' %>
             <%= link_to 'Data Publishing Charges', "#{stash_url_helpers.publishing_charges_path}", class: 'o-sites__group-item' %>
-            <%= link_to 'Best Practices', "#{stash_url_helpers.best_practices_path}", class: 'o-sites__group-item' %>
+            <%= link_to 'FAIR Data', "#{stash_url_helpers.best_practices_path}", class: 'o-sites__group-item' %>
             <%= link_to 'Frequently Asked Questions', stash_url_helpers.faq_path, class: 'o-sites__group-item' %>
           </div>
         </details>

--- a/stash_engine/app/views/stash_engine/pages/_why_share.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/_why_share.html.erb
@@ -15,7 +15,7 @@
       <div class="c-why-share__text-group">
         <h2 class="o-heading__level2-why-share">Submit</h2>
         <div>
-          <a href="<%= stash_url_helpers.submission_process_path(anchor: 'upload-methods') %>">Upload</a> your data files and receive a DOI.
+          Whether or not your data are related to an article, <a href="<%= stash_url_helpers.submission_process_path(anchor: 'upload-methods') %>">upload</a> your data files and receive a citable DOI.
         </div>
       </div>
     </div>
@@ -24,7 +24,7 @@
       <div class="c-why-share__text-group">
         <h2 class="o-heading__level2-why-share">Review</h2>
         <div>
-          Our <a href="<%= stash_url_helpers.submission_process_path(anchor: 'curation') %>">curators</a> will check and approve your submission. They may contact you with advice or questions.
+          Our <a href="<%= stash_url_helpers.submission_process_path(anchor: 'curation') %>">curators</a> will check through your submission to ensure the data are usable. They may contact you with advice or questions.
         </div>
       </div>
     </div>

--- a/stash_engine/app/views/stash_engine/pages/best_practices.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/best_practices.html.erb
@@ -1,3 +1,3 @@
-<% @page_title = 'Best practices for creating reusable data publications' %>
+<% @page_title = 'FAIR Data' %>
 
 <div class="markdown_styles"><%= render "layouts/best_practices" %></div>

--- a/stash_engine/app/views/stash_engine/pages/our_staff.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/our_staff.html.erb
@@ -1,3 +1,3 @@
-<% @page_title = 'Our Staff' %>
+<% @page_title = 'Our Team' %>
 
 <div class="markdown_styles about-page"><%= render "layouts/our_staff" %></div>

--- a/stash_engine/app/views/stash_engine/sessions/_login_info.html.erb
+++ b/stash_engine/app/views/stash_engine/sessions/_login_info.html.erb
@@ -2,11 +2,11 @@
   <h2>Dryad's Commitment to You</h2>
 
   <h3>Curation</h3>
-  <p>All datasets are curated by a team of Dryad curators</p>
+  <p>All datasets are curated to ensure they are Findable, Accessible, Interoperable, and Reusable</p>
 
   <h3>Compliance</h3>
-  <p>Long term adherence to funder and publisher mandates around open data</p>
+  <p>Enabling adherence to funder and publisher open data mandates</p>
 
   <h3>Community Supported</h3>
-  <p>Dryad is researcher-led and supported by our institutional and publisher communities</p>
+  <p>Dryad is researcher-led and supported by our institutional and publisher members</p>
 </div>

--- a/stash_engine/app/views/stash_engine/user_mailer/submitted.html.erb
+++ b/stash_engine/app/views/stash_engine/user_mailer/submitted.html.erb
@@ -6,4 +6,4 @@
 
 <p>To see the status of your dataset, visit your My Datasets page. Under "Submitted" If you click on the dataset you will have a preview of your data publication as well as access to your private URL. Please note this URL is not your permanent data citation.</p>
 
-<p>If you have questions or concerns, please visit the help page or get in touch with us <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>
+<p>Should you have any further questions about metadata, embargoing, or DOIs, please contact <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>


### PR DESCRIPTION
Per slack conversation w/ @dlowenberg:
1. In the email that goes to the author saying the process has begun (sorry for blanking which one it is) can you make sure at the end there is a line that says "Should you have any further questions about metadata, embargoing, or DOIs, please contact help@datadryad.org". [This is the only time we are going to even let them know they can embargo
2. On the Login page we have those three things Dryad commits. Can it be re-worded to say the following:
Curation
All datasets are curated to ensure they are Findable, Accessible, Interoperable, and Reusable
Compliance
Enabling adherence to funder and publisher open data mandates
Community Support
Dryad is researcher-led and supported by our institutional and publisher members
3. On the homepage where we have the 4 step process can you re-word "Review" to "Our Curators will check through your submission to ensure the data are usable. They may contact you with advice or questions". For "Submit" can you change it to "Whether or not your data are related to an article or not, upload your data files and receive a citable DOI"
4. On the Navigation bar can you change "Best Practices" to "FAIR Data", can you remove "Why Use Dryad" as a drop down and the content completely, and can you change "Our Staff" to "Our Team"