### PR TITLE
Adding the author patch again

### DIFF
--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -524,6 +524,10 @@ module StashEngine
       l_name = user.last_name
       orcid = (user.orcid.blank? ? nil : user.orcid)
       email = user.email
+
+      # TODO: This probably belongs somewhere else, but without it here, the affiliation sometimes doesn't exist
+      StashDatacite::AuthorPatch.patch! unless StashEngine::Author.method_defined?(:affiliation)
+
       affiliation = user.affiliation
       affiliation = StashDatacite::Affiliation.from_long_name(user.tenant.long_name) if affiliation.blank? &&
         user.tenant.present? && !%w[dryad localhost].include?(user.tenant.abbreviation.downcase)


### PR DESCRIPTION
For some reason, the affiliation method is not always added on my testing server. So I'm adding this patch until we rewrite the associated code to not use `user.affiliation`