### PR TITLE
Remove warning and email for large file fees

### DIFF
--- a/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -49,13 +49,14 @@
 	    fee waiver, are at an institution that is a Dryad member, or are publishing an assiciated article with journal
 	    that is a Dryad member, please <a href="mailto:help@datadryad.org">contact us</a> for assistance with payment.
 	</p>
-
+	
 	<% if @resource.identifier.large_files? %>
-	    <div class="js-alert c-alert--error" role="alert">
-		<div class="c-alert__text">
-		    This submisison has large files (over <%= filesize(StashEngine.app.payments.large_file_size) %>). We will contact you regarding fees. 
-		</div>
-	    </div>
+	    <p>
+		This submisison contains large files. 
+		For data packages in excess of <%= filesize(StashEngine.app.payments.large_file_size) %>,
+		submitters will be charged $50 for each additional 10GB,
+		or part thereof. (Submissions between 50 and 60GB = $50, between 60 and 70GB = $100, and so on).
+	    </p>
 	<% end %>
 	
 	<span><%= check_box_tag 'agree_to_payment', 'yes', (@resource.version_number > 1), class: 't-review__agree-to-license js-agrees' %></span>

--- a/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/licenses/_review.html.erb
@@ -44,10 +44,8 @@
 	<p>
 	    Dryad charges a fee for data publication that covers curation and preservation of published datasets. Upon
 	    publication of your dataset, you will receive an invoice for
-	    &dollar;<%=  StashEngine.app.payments.data_processing_charge / 100 %> (or more if larger than
-	    <%= filesize(StashEngine.app.payments.large_file_size) %>). If you have a
-	    fee waiver, are at an institution that is a Dryad member, or are publishing an assiciated article with journal
-	    that is a Dryad member, please <a href="mailto:help@datadryad.org">contact us</a> for assistance with payment.
+	    &dollar;<%=  StashEngine.app.payments.data_processing_charge / 100 %>. If you have any questions,
+	    please <a href="mailto:help@datadryad.org">contact us</a>.
 	</p>
 	
 	<% if @resource.identifier.large_files? %>

--- a/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -49,16 +49,6 @@ module StashEngine
            subject: "#{rails_env} dependency offline: #{dependency.name}")
     end
 
-    def large_file_notice(resource)
-      warn('Unable to send helpdesk notice; nil resource') unless resource.present?
-      return unless resource.present?
-      assign_variables(resource)
-      @message = message
-      mail(to: @helpdesk_email,
-           bcc: @bcc_emails,
-           subject: "#{rails_env} Large files in \"#{@resource.title}\" (doi:#{@resource.identifier_value})")
-    end
-
     def helpdesk_notice(resource, message)
       warn('Unable to send helpdesk notice; nil resource') unless resource.present?
       return unless resource.present?

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -62,16 +62,6 @@ module StashEngine
     after_create :email_author,
                  if: proc { |ca| %w[published embargoed].include?(ca.status) && latest_curation_status_changed? && !resource.skip_emails }
 
-    # Email the helpdesk when submitted and there are large files that the user must pay for
-    after_create :email_large_file_notice,
-                 if: proc { |ca|
-                       ca.submitted? &&
-                            latest_curation_status_changed? &&
-                            !resource.skip_emails &&
-                            resource.identifier.large_files? &&
-                            resource.identifier.user_must_pay?
-                     }
-
     # Email invitations to register ORCIDs to authors when published
     after_create :email_orcid_invitations,
                  if: proc { |ca| ca.published? && latest_curation_status_changed? && !resource.skip_emails }
@@ -154,10 +144,6 @@ module StashEngine
     # Triggered on a status of :published or :embargoed
     def email_author
       StashEngine::UserMailer.status_change(resource, status).deliver_now
-    end
-
-    def email_large_file_notice
-      StashEngine::UserMailer.large_file_notice(resource).deliver_now
     end
 
     # Triggered on a status of :published


### PR DESCRIPTION
Simplify the functionality for large file fees (https://github.com/CDL-Dryad/dryad-product-roadmap/issues/198)
- removes the automatic email to the helpdesk
- changes the warning box to a simpler paragraph

Note: automatic invoicing of large file fees will be added in a later PR.