### PR TITLE
Having a byebug in there makes the capistrano deploy poop out in the middle

### DIFF
--- a/stash_engine/lib/tasks/migration.rake
+++ b/stash_engine/lib/tasks/migration.rake
@@ -1,5 +1,4 @@
 require 'pp'
-require 'byebug'
 require_relative 'migration_import'
 require 'database_cleaner'
 namespace :dryad_migration do


### PR DESCRIPTION
I guess because that Gem isn't loaded in all environments and it affects rake tasks.