### PR TITLE
gemfile changes for database_cleaner for capistrano

### DIFF
--- a/stash_engine/Gemfile.lock
+++ b/stash_engine/Gemfile.lock
@@ -16,6 +16,7 @@ PATH
       cirneco (~> 0.9.27)
       ckeditor (~> 4.3.0)
       concurrent-ruby (~> 1.0)
+      database_cleaner
       datacite-mapping (~> 0.3)
       ezid-client (~> 1.5)
       filesize (~> 0.1.1)

--- a/stash_engine/stash_engine.gemspec
+++ b/stash_engine/stash_engine.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_dependency 'cirneco', '~> 0.9.27'
   s.add_dependency 'ckeditor', '~> 4.3.0' # lock to 4.x series since upgrading to 5.x blows up until we figure out the upgrade path
   s.add_dependency 'concurrent-ruby', '~> 1.0'
+  s.add_dependency 'database_cleaner' # for one migration task, but need to keep capistrano from barfing can remove after migration
   s.add_dependency 'datacite-mapping', '~> 0.3'
   s.add_dependency 'ezid-client', '~> 1.5'
   s.add_dependency 'filesize', '~> 0.1.1'


### PR DESCRIPTION
Another fix because capistrano hooks into rake and picking up dependency there even though this file isn't used for deploy.