### PR TITLE
Update prod notifier

### DIFF
--- a/stash-notifier/config/notifier.yml
+++ b/stash-notifier/config/notifier.yml
@@ -37,7 +37,7 @@ migration:
 
 production:
   <<: *defaults
-  update_base_url: https://dryadx2-prd.cdlib.org/stash/stash/dataset
+  update_base_url: https://datadryad.org/stash/dataset
   oai_base_url: http://uc3-mrtoai-prd.cdlib.org:37001/mrtoai/oai/v2
   sets:
     - cdl_dryad

--- a/stash-notifier/config/notifier.yml
+++ b/stash-notifier/config/notifier.yml
@@ -34,3 +34,21 @@ migration:
   oai_base_url: http://uc3-mrtoai-prd.cdlib.org:37001/mrtoai/oai/v2
   sets:
     - cdl_dryad
+
+production:
+  <<: *defaults
+  update_base_url: https://dryadx2-prd.cdlib.org/stash/stash/dataset
+  oai_base_url: http://uc3-mrtoai-prd.cdlib.org:37001/mrtoai/oai/v2
+  sets:
+    - cdl_dryad
+    - lbnl_dash
+    - uci_dash
+    - ucb_dash
+    - ucd_lib_dash
+    - ucla_dash
+    - ucm_dash
+    - ucop_dash
+    - ucr_lib_dash
+    - ucsb_dash
+    - ucsc_dash
+    - ucsf_lib_datashare


### PR DESCRIPTION
These are simple changes to set up the notifier, which we'll use in production.  For now this is being run against the migration environment with just the dryad collection.  When we go live, we should disable the migration environment and use the production one to notify.

Until release we don't really want to run this against production since it includes sets/collections that are currently being notified to existing Dash from the harvester script.  Those notifications will fail in Dryad since those items will not exist in our database until they are migrated from Dash.