### PR TITLE
Rake tasks for MDC log combining functions & log validation task

### DIFF
--- a/stash_engine/lib/tasks/counter.rake
+++ b/stash_engine/lib/tasks/counter.rake
@@ -17,6 +17,12 @@ namespace :counter do
   end
 
   desc 'get and combine files from the other servers'
+  task :remove_old_logs do
+    lc = Counter::LogCombiner.new(log_directory: LOG_DIRECTORY, scp_hosts: SCP_HOSTS, scp_path: SCP_PATH)
+    lc.remove_old_logs(days_old: 60)
+  end
+
+  desc 'get and combine files from the other servers'
   task :combine_filesss do
     Dir.chdir(LOG_DIRECTORY) do
 

--- a/stash_engine/lib/tasks/counter.rake
+++ b/stash_engine/lib/tasks/counter.rake
@@ -1,6 +1,7 @@
 require 'byebug'
 require 'net/scp'
 require_relative 'counter/validate_file'
+require_relative 'counter/log_combiner'
 
 namespace :counter do
   LOG_DIRECTORY = '/Users/sfisher/workspace/direct-to-cdl-dryad/dryad/log'.freeze
@@ -10,6 +11,13 @@ namespace :counter do
 
   desc 'get and combine files from the other servers'
   task :combine_files do
+    lc = Counter::LogCombiner.new(log_directory: LOG_DIRECTORY, scp_hosts: SCP_HOSTS, scp_path: SCP_PATH)
+    lc.copy_missing_files
+    lc.combine_logs
+  end
+
+  desc 'get and combine files from the other servers'
+  task :combine_filesss do
     Dir.chdir(LOG_DIRECTORY) do
 
       filenames = Dir.glob('*.log')
@@ -27,7 +35,7 @@ namespace :counter do
            .merge(combined_file: File.exist?("#{x}_combined"))]
       end.to_h
 
-      # go through fils and copy and combine them
+      # go through files and copy and combine them
       outhash.each do |f, v|
         bad_scp = false
 
@@ -61,7 +69,7 @@ namespace :counter do
 
   end # end of task
 
-  desc 'validate logs that come after this on the command line'
+  desc 'validate log filenames (that come after rake task)'
   task :validate_logs do
     ARGV.each do |filename|
       next if filename == 'counter:validate_logs'

--- a/stash_engine/lib/tasks/counter.rake
+++ b/stash_engine/lib/tasks/counter.rake
@@ -2,6 +2,7 @@ require 'net/scp'
 require_relative 'counter/validate_file'
 require_relative 'counter/log_combiner'
 
+# rubocop:disable Metrics/BlockLength
 namespace :counter do
   LOG_DIRECTORY = '/apps/dryad/apps/ui/current/log'.freeze
   SCP_HOSTS = ['uc3-dryaduix2-stg-2c.cdlib.org'].freeze
@@ -36,3 +37,4 @@ namespace :counter do
     exit # makes the arguments not be interpreted as other rake tasks
   end # end of task
 end
+# rubocop:enable Metrics/BlockLength

--- a/stash_engine/lib/tasks/counter.rake
+++ b/stash_engine/lib/tasks/counter.rake
@@ -1,82 +1,31 @@
-require 'byebug'
 require 'net/scp'
 require_relative 'counter/validate_file'
 require_relative 'counter/log_combiner'
 
 namespace :counter do
-  LOG_DIRECTORY = '/Users/sfisher/workspace/direct-to-cdl-dryad/dryad/log'.freeze
+  LOG_DIRECTORY = '/apps/dryad/apps/ui/current/log'.freeze
   SCP_HOSTS = ['uc3-dryaduix2-stg-2c.cdlib.org'].freeze
-  SCP_PATH = '/apps/dryad/apps/ui/current/log'.freeze
   PRIMARY_FN_PATTERN = /counter_\d{4}-\d{2}-\d{2}.log/
 
   desc 'get and combine files from the other servers'
   task :combine_files do
-    lc = Counter::LogCombiner.new(log_directory: LOG_DIRECTORY, scp_hosts: SCP_HOSTS, scp_path: SCP_PATH)
+    lc = Counter::LogCombiner.new(log_directory: LOG_DIRECTORY, scp_hosts: SCP_HOSTS, scp_path: LOG_DIRECTORY)
     lc.copy_missing_files
     lc.combine_logs
   end
 
-  desc 'get and combine files from the other servers'
+  desc 'remove log files we are not keeping because of our privacy policy'
   task :remove_old_logs do
-    lc = Counter::LogCombiner.new(log_directory: LOG_DIRECTORY, scp_hosts: SCP_HOSTS, scp_path: SCP_PATH)
+    lc = Counter::LogCombiner.new(log_directory: LOG_DIRECTORY, scp_hosts: SCP_HOSTS, scp_path: LOG_DIRECTORY)
     lc.remove_old_logs(days_old: 60)
   end
 
-  desc 'get and combine files from the other servers'
-  task :combine_filesss do
-    Dir.chdir(LOG_DIRECTORY) do
-
-      filenames = Dir.glob('*.log')
-      counter_filenames = filenames.map { |fn| File.basename(fn) }.keep_if { |fn| fn.match(PRIMARY_FN_PATTERN) }
-      counter_filenames.delete(Time.new.strftime('counter_%Y-%m-%d.log'))
-      counter_filenames.sort!
-
-      # this looks complicated, but it just produces a hash like the following of what files exist
-      # {"counter_2019-08-01.log"=>{0=>false, :combined_file=>false},
-      # "counter_2019-08-02.log"=>{0=>true, :combined_file=>true} }.
-      # The numbers are other servers in the cluster
-      outhash = counter_filenames.map do |x|
-        [x,
-         SCP_HOSTS.map.with_index { |_v, idx| [idx, File.exist?("#{x}_#{idx}")] }.to_h
-           .merge(combined_file: File.exist?("#{x}_combined"))]
-      end.to_h
-
-      # go through files and copy and combine them
-      outhash.each do |f, v|
-        bad_scp = false
-
-        # copy other server's files over if possible
-        v.each_pair do |k2, v2|
-          next unless k2.class == Integer
-          begin
-            if v2 == false
-              puts "downloading #{f}"
-              Net::SCP.download!(SCP_HOSTS[k2], 'dryad', File.join(SCP_PATH, f), "#{f}_#{k2}")
-            end
-          rescue Net::SCP::Error => e
-            raise e unless e.to_s.include?('No such file or directory')
-            puts "Skipping #{f}: file doesn't exist on secondary server"
-            bad_scp = true
-            break
-          end
-        end
-
-        # sort and combine logs if possible
-        next if v[:combined_file] || bad_scp
-        puts "combining files to #{f}_combined"
-        other_files = 0.upto(SCP_HOSTS.length - 1).map { |i| "#{f}_#{i}" }.join(' ')
-        `cat #{f} #{other_files} | sort > #{f}_combined` # now combine & sort them in linux
-      end
-    end # end of working inside directory
-  end # end of task
-
-  desc 'cleanup old logs'
-  task :cleanup_logs do
-
-  end # end of task
-
-  desc 'validate log filenames (that come after rake task)'
+  desc 'validate counter logs format (filenames come after rake task)'
   task :validate_logs do
+    if ARGV.length == 1
+      puts 'Please enter the filenames of files to validate, separated by spaces'
+      exit
+    end
     ARGV.each do |filename|
       next if filename == 'counter:validate_logs'
       puts "Validating #{filename}"

--- a/stash_engine/lib/tasks/counter.rake
+++ b/stash_engine/lib/tasks/counter.rake
@@ -1,0 +1,63 @@
+require 'byebug'
+require 'net/scp'
+
+namespace :counter do
+  LOG_DIRECTORY = '/Users/sfisher/workspace/direct-to-cdl-dryad/dryad/log'.freeze
+  SCP_HOSTS = ['uc3-dryaduix2-stg-2c.cdlib.org'].freeze
+  SCP_PATH = '/apps/dryad/apps/ui/current/log'.freeze
+  PRIMARY_FN_PATTERN = /counter_\d{4}-\d{2}-\d{2}.log/
+
+  desc 'get and combine files from the other servers'
+  task :combine_files do
+    Dir.chdir(LOG_DIRECTORY) do
+
+      filenames = Dir.glob('*.log')
+      counter_filenames = filenames.map { |fn| File.basename(fn) }.keep_if { |fn| fn.match(PRIMARY_FN_PATTERN) }
+      counter_filenames.delete(Time.new.strftime('counter_%Y-%m-%d.log'))
+      counter_filenames.sort!
+
+      # this looks complicated, but it just produces a hash like the following of what files exist
+      # {"counter_2019-08-01.log"=>{0=>false, :combined_file=>false},
+      # "counter_2019-08-02.log"=>{0=>true, :combined_file=>true} }.
+      # The numbers are other servers in the cluster
+      outhash = counter_filenames.map do |x|
+        [x,
+         SCP_HOSTS.map.with_index { |_v, idx| [idx, File.exist?("#{x}_#{idx}")] }.to_h
+           .merge(combined_file: File.exist?("#{x}_combined"))]
+      end.to_h
+
+      # go through fils and copy and combine them
+      outhash.each do |f, v|
+        bad_scp = false
+
+        # copy other server's files over if possible
+        v.each_pair do |k2, v2|
+          if k2.class == Integer
+            begin
+              if v2 == false
+                puts "downloading #{f}"
+                Net::SCP.download!(SCP_HOSTS[k2], 'dryad', File.join(SCP_PATH, f), "#{f}_#{k2}")
+              end
+            rescue Net::SCP::Error => e
+              raise e unless e.to_s.include?('No such file or directory')
+              puts "Skipping #{f}: file doesn't exist on secondary server"
+              bad_scp = true
+              break
+            end
+          end
+        end
+
+        # sort and combine logs if possible
+        next if v[:combined_file] || bad_scp
+        puts "combining files to #{f}_combined"
+        other_files = 0.upto(SCP_HOSTS.length - 1).map{|i| "#{f}_#{i}" }.join(' ')
+        `cat #{f} #{other_files} | sort > #{f}_combined` # now combine & sort them in linux
+      end
+    end # end of working inside directory
+
+    desc 'cleanup old logs'
+    task :cleanup_logs do
+
+    end
+  end
+end

--- a/stash_engine/lib/tasks/counter/log_combiner.rb
+++ b/stash_engine/lib/tasks/counter/log_combiner.rb
@@ -1,0 +1,60 @@
+require 'net/scp'
+
+module Counter
+  class LogCombiner
+
+    USERNAME = 'dryad'.freeze
+
+    def initialize(log_directory:, scp_hosts:, scp_path:)
+      @log_directory = log_directory
+      @scp_hosts = scp_hosts
+      @scp_path = scp_path
+      @primary_fn_pattern = /counter_\d{4}-\d{2}-\d{2}.log/
+
+      Dir.chdir(@log_directory) do
+        filenames = Dir.glob('*.log')
+        @primary_filenames = filenames.map {|fn| File.basename(fn)}.keep_if {|fn| fn.match(@primary_fn_pattern)}
+        @primary_filenames.delete(Time.new.strftime('counter_%Y-%m-%d.log')) # remove today's file, not done yet
+        @primary_filenames.sort!
+      end
+    end
+
+    def copy_missing_files
+      Dir.chdir(@log_directory) do
+        @primary_filenames.each do |fn|
+          @scp_hosts.each_with_index do |host, idx|
+            next if File.exist?("#{fn}_#{idx}")
+
+            scp_file(filename: fn, host: host, dest_file: "#{fn}_#{idx}")
+          end
+        end
+      end
+    end
+
+    def combine_logs
+      Dir.chdir(@log_directory) do
+        @primary_filenames.each do |fn|
+          next if File.exist?("#{fn}_combined")
+
+          filenames = Dir.glob("#{fn}_[0-9]").join(' ')  # assumes no more than 11 UI workers
+          `cat #{fn} #{filenames} | sort > #{fn}_combined`
+          puts "combined: #{fn} #{filenames} -> #{fn}_combined"
+        end
+      end
+    end
+
+
+    # --- Private methods below ---
+
+    private
+
+    def scp_file(filename:, host:, dest_file:)
+      Net::SCP.download!(host, USERNAME, File.join(@scp_path, filename), dest_file)
+      puts "downloaded #{host}:#{filename}"
+    rescue Net::SCP::Error => e
+      raise e unless e.to_s.include?('No such file or directory')
+      puts "Skipped downloading #{host}:#{filename} file doesn't exist on secondary server"
+    end
+
+  end
+end

--- a/stash_engine/lib/tasks/counter/log_combiner.rb
+++ b/stash_engine/lib/tasks/counter/log_combiner.rb
@@ -1,19 +1,22 @@
 require 'net/scp'
+require 'time'
 
 module Counter
   class LogCombiner
 
     USERNAME = 'dryad'.freeze
+    PRIMARY_FN_PATTERN = /^counter_\d{4}-\d{2}-\d{2}.log$/.freeze
+    ANY_LOG_FN_PATTERN = /^counter_(\d{4})-(\d{2})-(\d{2}).log(|_\d{1}|_combined)$/.freeze
 
     def initialize(log_directory:, scp_hosts:, scp_path:)
       @log_directory = log_directory
       @scp_hosts = scp_hosts
       @scp_path = scp_path
-      @primary_fn_pattern = /counter_\d{4}-\d{2}-\d{2}.log/
+      @scp_path = scp_path
 
       Dir.chdir(@log_directory) do
         filenames = Dir.glob('*.log')
-        @primary_filenames = filenames.map {|fn| File.basename(fn)}.keep_if {|fn| fn.match(@primary_fn_pattern)}
+        @primary_filenames = filenames.map {|fn| File.basename(fn)}.keep_if {|fn| fn.match(PRIMARY_FN_PATTERN)}
         @primary_filenames.delete(Time.new.strftime('counter_%Y-%m-%d.log')) # remove today's file, not done yet
         @primary_filenames.sort!
       end
@@ -39,6 +42,20 @@ module Counter
           filenames = Dir.glob("#{fn}_[0-9]").join(' ')  # assumes no more than 11 UI workers
           `cat #{fn} #{filenames} | sort > #{fn}_combined`
           puts "combined: #{fn} #{filenames} -> #{fn}_combined"
+        end
+      end
+    end
+
+    def remove_old_logs(days_old: 60)
+      Dir.chdir(@log_directory) do
+        log_filenames = Dir.glob('*.log*').map {|fn| File.basename(fn)}.keep_if {|fn| fn.match(ANY_LOG_FN_PATTERN)}
+        log_filenames.each do |fn|
+          m = ANY_LOG_FN_PATTERN.match(fn)
+          log_date = Time.new(m[1], m[2], m[3])
+          if log_date < Time.new - days_old.days
+            File.delete(fn)
+            puts "Deleted #{fn}"
+          end
         end
       end
     end

--- a/stash_engine/lib/tasks/counter/log_combiner.rb
+++ b/stash_engine/lib/tasks/counter/log_combiner.rb
@@ -5,8 +5,8 @@ module Counter
   class LogCombiner
 
     USERNAME = 'dryad'.freeze
-    PRIMARY_FN_PATTERN = /^counter_\d{4}-\d{2}-\d{2}.log$/.freeze
-    ANY_LOG_FN_PATTERN = /^counter_(\d{4})-(\d{2})-(\d{2}).log(|_\d{1}|_combined)$/.freeze
+    PRIMARY_FN_PATTERN = /^counter_\d{4}-\d{2}-\d{2}.log$/
+    ANY_LOG_FN_PATTERN = /^counter_(\d{4})-(\d{2})-(\d{2}).log(|_\d{1}|_combined)$/
 
     def initialize(log_directory:, scp_hosts:, scp_path:)
       @log_directory = log_directory
@@ -16,7 +16,7 @@ module Counter
 
       Dir.chdir(@log_directory) do
         filenames = Dir.glob('*.log')
-        @primary_filenames = filenames.map {|fn| File.basename(fn)}.keep_if {|fn| fn.match(PRIMARY_FN_PATTERN)}
+        @primary_filenames = filenames.map { |fn| File.basename(fn) }.keep_if { |fn| fn.match(PRIMARY_FN_PATTERN) }
         @primary_filenames.delete(Time.new.strftime('counter_%Y-%m-%d.log')) # remove today's file, not done yet
         @primary_filenames.sort!
       end
@@ -39,7 +39,7 @@ module Counter
         @primary_filenames.each do |fn|
           next if File.exist?("#{fn}_combined")
 
-          filenames = Dir.glob("#{fn}_[0-9]").join(' ')  # assumes no more than 11 UI workers
+          filenames = Dir.glob("#{fn}_[0-9]").join(' ') # assumes no more than 11 UI workers
           `cat #{fn} #{filenames} | sort > #{fn}_combined`
           puts "combined: #{fn} #{filenames} -> #{fn}_combined"
         end
@@ -48,7 +48,7 @@ module Counter
 
     def remove_old_logs(days_old: 60)
       Dir.chdir(@log_directory) do
-        log_filenames = Dir.glob('*.log*').map {|fn| File.basename(fn)}.keep_if {|fn| fn.match(ANY_LOG_FN_PATTERN)}
+        log_filenames = Dir.glob('*.log*').map { |fn| File.basename(fn) }.keep_if { |fn| fn.match(ANY_LOG_FN_PATTERN) }
         log_filenames.each do |fn|
           m = ANY_LOG_FN_PATTERN.match(fn)
           log_date = Time.new(m[1], m[2], m[3])
@@ -59,7 +59,6 @@ module Counter
         end
       end
     end
-
 
     # --- Private methods below ---
 

--- a/stash_engine/lib/tasks/counter/log_combiner.rb
+++ b/stash_engine/lib/tasks/counter/log_combiner.rb
@@ -12,7 +12,6 @@ module Counter
       @log_directory = log_directory
       @scp_hosts = scp_hosts
       @scp_path = scp_path
-      @scp_path = scp_path
 
       Dir.chdir(@log_directory) do
         filenames = Dir.glob('*.log')

--- a/stash_engine/lib/tasks/counter/validate_file.rb
+++ b/stash_engine/lib/tasks/counter/validate_file.rb
@@ -1,0 +1,163 @@
+require 'time'
+require 'ipaddr'
+require 'uri'
+
+# this is a long, but very consistent and simple class, so suck it rubocop
+# rubocop:disable Metrics/ClassLength
+module Counter
+  class ValidateFile
+
+    def initialize(filename:)
+      @filename = filename
+      full_path = File.expand_path(filename)
+      @out_file = File.join(File.dirname(full_path), "#{File.basename(full_path)}-fixed")
+    end
+
+    VALIDATION_METHODS = %w[event_time ip_address session_cookie user_cookie user_id request_url
+                            doi filename size user_agent title publisher publisher_id authors publication_date version
+                            alternate_id target_url year_of_publication].freeze
+    def validate_file
+      File.open(@out_file, 'w:UTF-8') do |f|
+        File.open(@filename).each_with_index do |line, index|
+          @badline = false # badline is set to true if it doesn't validate
+          @line_no = index
+          my_line = line.strip
+          next if my_line.start_with?('#') || my_line == ''
+
+          validate_line(line: my_line)
+          f.write("#{my_line}\n") if @badline == false
+        end
+      end
+    end
+
+    def validate_line(line:)
+      pieces = line.split("\t")
+      return error(msg: 'Incorrect number of pieces') if pieces.length != VALIDATION_METHODS.length
+
+      VALIDATION_METHODS.each_with_index do |meth, index|
+        send("validate_#{meth}", pieces[index])
+      end
+    end
+
+    # must be present and be iso8601 string
+    def validate_event_time(item)
+      error(msg: 'Invalid iso8601 string', item: __method__.to_s) unless valid_iso_8601(item)
+    end
+
+    # must have an IP address of some kind
+    def validate_ip_address(item)
+      error(msg: 'Invalid IP address string', item: __method__.to_s) if (begin
+                                                                           IPAddr.new(item)
+                                                                         rescue StandardError
+                                                                           nil
+                                                                         end).nil?
+    end
+
+    # don't know what these exactly look like, make stricter later if needed
+    def validate_session_cookie(_item)
+      nil
+    end
+
+    # don't know what these exactly look like, make stricter later if needed
+    def validate_user_cookie(_item)
+      nil
+    end
+
+    # don't know what these exactly look like, make stricter later if needed
+    def validate_user_id(_item)
+      nil
+    end
+
+    def validate_request_url(item)
+      error(msg: 'Invalid URL', item: __method__.to_s) unless item =~ URI::DEFAULT_PARSER.make_regexp
+    end
+
+    # see https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+    def validate_doi(item)
+      error(msg: 'Invalid DOI', item: __method__.to_s) unless item =~ %r{^doi:10.\d{4,9}/[-._\;()/:A-Z0-9]+$}i
+    end
+
+    # make stricter later if needed
+    def validate_filename(_item)
+      nil
+    end
+
+    # nothing or - or a numeric
+    def validate_size(item)
+      error(msg: 'Invalid size', item: __method__.to_s) unless item =~ /^$|^-$|^\d+$/
+    end
+
+    # just a string, so ignore
+    def validate_user_agent(_item)
+      nil
+    end
+
+    # just a string, but shouldn't be blank
+    def validate_title(item)
+      error(msg: 'Title may not be blank', item: __method__.to_s) if blank?(item)
+    end
+
+    # just a string, but shouldn't be blank
+    def validate_publisher(item)
+      error(msg: 'Publisher may not be blank', item: __method__.to_s) if blank?(item)
+    end
+
+    def validate_publisher_id(item)
+      error(msg: 'Publisher ID may not be blank', item: __method__.to_s) if blank?(item)
+      error(msg: 'Publisher ID must match a certain format', item: __method__.to_s) unless item =~ %r{^grid.|^isni:|^https://ror.org/}
+    end
+
+    def validate_authors(item)
+      error(msg: 'Authors may not be blank', item: __method__.to_s) if blank?(item)
+    end
+
+    # a bazillion formats, just checking it's not blank here
+    def validate_publication_date(item)
+      error(msg: 'Publication date may not be blank', item: __method__.to_s) if blank?(item)
+    end
+
+    # I'm not really sure this needs to be set, does it?
+    def validate_version(_item)
+      nil
+    end
+
+    # doesn't need to be set
+    def validate_alternate_id(_item)
+      nil
+    end
+
+    # I believe there should be a target URL, even if it's just a metadata page about itself?
+    def validate_target_url(item)
+      error(msg: 'Invalid URL', item: __method__.to_s) unless item =~ URI::DEFAULT_PARSER.make_regexp
+    end
+
+    def validate_year_of_publication(item)
+      error(msg: 'Invalid year of publication', item: __method__.to_s) unless item =~ /^\d+$/i
+    end
+
+    private
+
+    # private helper methods for this class below here
+
+    def error(msg:, item: nil)
+      @badline = true
+      if item.nil?
+        puts "#{@filename}:#{@line_no + 1} #{msg}"
+      else
+        puts "#{@filename}:#{@line_no + 1}:#{item} #{msg}"
+      end
+    end
+
+    def valid_iso_8601(t)
+      Time.iso8601(t)
+      true
+    rescue ArgumentError
+      false
+    end
+
+    def blank?(i)
+      ['-', ''].include?(i)
+    end
+  end
+end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
This is for github numbers 389 and 228 to work through the MDC/Counter logs.

- Counter rake tasks to scp & combine log files from all servers (so we can process them from the processor) and remove old logs.
- A validator to check the basic format of counter logs to be sure they seem valid since there were some problems with ones Ryan had originally.

These will eventually be added to the log with the Python script to cron processing daily.

1. combine log files
2. run python script to generate and submit (once we're in production) stats from combined daily logs.
3. delete old logs per our privacy policy.

I'll do a separate PR for actually putting it in the cron once I've tested it working on the server and it only runs in production environment. 

