### PR TITLE
Update to query behind the Curation page

### DIFF
--- a/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/admin_datasets_controller.rb
@@ -14,17 +14,12 @@ module StashEngine
     TENANT_IDS = Tenant.all.map(&:tenant_id)
 
     # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
-    # rubocop:disable Metrics/AbcSize
     def index
       my_tenant_id = (current_user.role == 'admin' ? current_user.tenant_id : nil)
       @all_stats = Stats.new
       @seven_day_stats = Stats.new(tenant_id: my_tenant_id, since: (Time.new.utc - 7.days))
 
-      @datasets = StashEngine::AdminDatasets::CurationTableRow.where(search_term: params[:q], tenant_filter: params[:tenant_id],
-        status_filter: params[:curation_status], publication_filter: params[:publication_name],
-        sort_column: params[:sort], sort_direction: params[:direction])
-
-      @datasets = Kaminari.paginate_array(@datasets).page(@page).per(@page_size)
+      @datasets = Kaminari.paginate_array(StashEngine::AdminDatasets::CurationTableRow.where(params)).page(@page).per(@page_size)
 
       @publications = InternalDatum.where(data_type: 'publicationName').order(:value).pluck(:value).uniq
       @pub_name = params[:publication_name] || nil
@@ -34,7 +29,6 @@ module StashEngine
         format.csv
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     # Unobtrusive Javascript (UJS) to do AJAX by running javascript
     def data_popup

--- a/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+# This is NOT an ActiveRecord model and does not persist data!!
+# This class represents a row in the Admin's Curation page. It only retrieves the information
+# necessary to populate the table on that page.
+module StashEngine
+  module AdminDatasets
+    class CurationTableRow
+
+      attr_reader :publication_name
+      attr_reader :identifier_id, :identifier, :storage_size, :search_words
+      attr_reader :resource_id, :title, :publication_date, :tenant_id
+      attr_reader :resource_state_id, :resource_state
+      attr_reader :curation_activity_id, :status, :updated_at
+      attr_reader :editor_id, :editor_name
+      attr_reader :author_names
+      attr_reader :relevance
+
+      SELECT_CLAUSE = <<-SQL
+        SELECT seid.value,
+          sei.id, sei.identifier, sei.storage_size, sei.search_words,
+          ser.id, ser.title, ser.publication_date, ser.tenant_id,
+          sers.id, sers.resource_state,
+          seca.id, seca.status, seca.updated_at,
+          seu.id, seu.last_name, seu.first_name,
+          (SELECT GROUP_CONCAT(DISTINCT sea.author_last_name ORDER BY sea.author_last_name SEPARATOR '; ')
+           FROM stash_engine_authors sea
+           WHERE sea.resource_id = ser.id)
+      SQL
+
+      FROM_CLAUSE = <<-SQL
+          FROM stash_engine_resources ser
+          LEFT OUTER JOIN stash_engine_identifiers sei ON ser.identifier_id = sei.id
+          LEFT OUTER JOIN stash_engine_internal_data seid ON sei.id = seid.identifier_id AND seid.data_type = 'publicationName'
+          LEFT OUTER JOIN stash_engine_users seu ON ser.current_editor_id = seu.id
+          INNER JOIN (SELECT MAX(r2.id) r_id FROM stash_engine_resources r2 GROUP BY r2.identifier_id) j1 ON j1.r_id = ser.id
+          LEFT OUTER JOIN (SELECT rs2.resource_id, MAX(rs2.id) latest_resource_state_id FROM stash_engine_resource_states rs2 GROUP BY rs2.resource_id) j2 ON j2.resource_id = ser.id
+          LEFT OUTER JOIN (SELECT ca2.resource_id, MAX(ca2.id) latest_curation_activity_id FROM stash_engine_curation_activities ca2 GROUP BY ca2.resource_id) j3 ON j3.resource_id = ser.id
+          LEFT OUTER JOIN stash_engine_resource_states sers ON sers.id = j2.latest_resource_state_id
+          LEFT OUTER JOIN stash_engine_curation_activities seca ON seca.id = j3.latest_curation_activity_id
+      SQL
+
+      SEARCH_CLAUSE = 'MATCH(sei.search_words) AGAINST(%{term}) > 05'
+      SCAN_CLAUSE = 'sei.search_words LIKE %{term}'
+      TENANT_CLAUSE = 'ser.tenant_id = %{term}'
+      STATUS_CLAUSE = 'seca.status = %{term}'
+      PUBLICATION_CLAUSE = 'seid.value = %{term}'
+
+      def initialize(result)
+        return unless result.is_a?(Array) && result.length >= 18
+
+        # Convert the array of results into attribute values
+        @publication_name = result[0]
+        @identifier_id = result[1]
+        @identifier = result[2]
+        @storage_size = result[3]
+        @search_words = result[4]
+        @resource_id = result[5]
+        @title = result[6]
+        @publication_date = result[7]
+        @tenant_id = result[8]
+        @resource_state_id = result[9]
+        @resource_state = result[10]
+        @curation_activity_id = result[11]
+        @status = result[12]
+        @updated_at = result[13]
+        @editor_id = result[14]
+        @editor_name = result[15..16].join(', ')
+        @author_names = result[17]
+        @relevance = result.length > 18 ? result[18] : nil
+      end
+
+      class << self
+
+        def where(search_term:, tenant_filter:, status_filter:, publication_filter:, sort_column:, sort_direction:)
+          # If a search term was provided include the relevance score in the results for sorting purposes
+          relevance = search_term.present? ? ", (#{add_term_to_clause(SEARCH_CLAUSE, search_term)}) relevance" : ''
+
+          query = " \
+            #{SELECT_CLAUSE}
+            #{relevance}
+            #{FROM_CLAUSE}
+            #{build_where_clause(search_term, tenant_filter, status_filter, publication_filter)}
+            #{build_order_clause(search_term.present?, sort_column, sort_direction)}
+          "
+          results = ActiveRecord::Base.connection.execute(query).map { |result| new(result) }
+          # If the user is trying to sort by author names, then
+          (sort_column == 'author_names' ? sort_by_author_names(results, sort_direction) : results)
+        end
+
+        private
+
+        # Create the WHERE portion of the query based on the search and filters set by the user
+        def build_where_clause(search_term, tenant_filter, status_filter, publication_filter)
+          where_clause = [
+            (search_term.present? ? "((#{add_term_to_clause(SEARCH_CLAUSE, search_term)}) OR \
+              #{add_term_to_clause(SCAN_CLAUSE, "%#{search_term}%")})" : nil),
+            add_term_to_clause(TENANT_CLAUSE, tenant_filter),
+            add_term_to_clause(STATUS_CLAUSE, status_filter),
+            add_term_to_clause(PUBLICATION_CLAUSE, publication_filter)
+          ].compact
+          where_clause.empty? ? '' : " WHERE #{where_clause.join(' AND ')}"
+        end
+
+        # Create the ORDER BY portion of the query. If the user included a search term order by relevance first!
+        # We cannot sort by author_names here, so ignore if that is the :sort_column
+        def build_order_clause(searching, column, direction)
+          column = 'last_name' if column == 'editor_name'
+          order_by = [
+            (searching ? 'relevance DESC' : nil),
+            (column.present? && column != 'author_names' ? "#{column} #{direction || 'ASC'}" : nil)
+          ].compact
+          order_by.empty? ? '' : "ORDER BY #{order_by.join(', ')}"
+        end
+
+        def sort_by_author_names(results, direction)
+          results.sort do |a, b|
+            direction.downcase == 'desc' ? b.author_names.downcase <=> a.author_names.downcase : a.author_names.downcase <=> b.author_names.downcase
+          end
+        end
+
+        # Swap a term into the SQL snippet/clause
+        def add_term_to_clause(clause, term)
+          return nil unless clause.present? && term.present?
+          format(clause.to_s, term: ActiveRecord::Base.connection.quote(term))
+        end
+
+      end
+
+    end
+  end
+end

--- a/stash_engine/app/models/stash_engine/user.rb
+++ b/stash_engine/app/models/stash_engine/user.rb
@@ -22,6 +22,10 @@ module StashEngine
       "#{first_name} #{last_name}".strip
     end
 
+    def name_last_first
+      [last_name, first_name].join(', ')
+    end
+
     def superuser?
       role == 'superuser'
     end

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -38,7 +38,7 @@
         <% end %>
       </td>
       <td class="c-admin-hide-border-right" id="js-curation-state-<%= dataset.identifier_id %>">
-        <%= dataset.status %>
+        <%= StashEngine::CurationActivity.readable_status(dataset.status) %>
       </td>
       <td class="c-admin-hide-border-left">
         <% if %w[admin superuser].include?(current_user.role) && dataset.resource_state == 'submitted' && %w[published embargoed].include?(dataset.status) %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -41,7 +41,8 @@
         <%= StashEngine::CurationActivity.readable_status(dataset.status) %>
       </td>
       <td class="c-admin-hide-border-left">
-        <% if %w[admin superuser].include?(current_user.role) && dataset.resource_state == 'submitted' && %w[published embargoed].include?(dataset.status) %>
+        <% if %w[admin superuser].include?(current_user.role) && dataset.resource_state == 'submitted' &&
+          !%w[published embargoed].include?(dataset.status) %>
           <%= form_tag({ controller: '/stash_engine/admin_datasets',
                          action: 'curation_activity_popup', id: dataset.resource_id },
                          method: :get, remote: true) do -%>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -52,7 +52,13 @@
           <% end %>
         <% end %>
       </td>
-      <td><%= dataset.author_names %></td>
+      <td>
+        <% if dataset.author_names.length > 50 %>
+          <%= "#{dataset.author_names[0..49]} ..." %>
+        <% else %>
+          <%= dataset.author_names %>
+        <% end %>
+      </td>
       <td><%= dataset.identifier %></td>
       <td class="c-admin-hide-border-right" id="js-curation-activity-date-<%= dataset.identifier_id %>">
         <%= formatted_datetime(dataset.updated_at) %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -7,45 +7,43 @@
     <th class="c-admin-table <%= sort_display('status', @sort_column) %>" colspan="2">
       <%= sort_by 'status', title: 'Status', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table <%= sort_display('author', @sort_column) %>">
-      <%= sort_by 'author', title: 'Author', current_column: @sort_column %>
+    <th class="c-admin-table <%= sort_display('author_names', @sort_column) %>">
+      <%= sort_by 'author_names', title: 'Author', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table <%= sort_display('doi', @sort_column) %>">
-      <%= sort_by 'doi', title: 'DOI', current_column: @sort_column %>
+    <th class="c-admin-table <%= sort_display('identifier', @sort_column) %>">
+      <%= sort_by 'identifier', title: 'DOI', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table <%= sort_display('last_modified', @sort_column) %>" colspan="2">
-      <%= sort_by 'last_modified', title: 'Last Modified', current_column: @sort_column %>
+    <th class="c-admin-table <%= sort_display('updated_at', @sort_column) %>" colspan="2">
+      <%= sort_by 'updated_at', title: 'Last Modified', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table <%= sort_display('editor', @sort_column) %>">
-      <%= sort_by 'editor', title: 'Last modified by', current_column: @sort_column %>
+    <th class="c-admin-table <%= sort_display('editor_name', @sort_column) %>">
+      <%= sort_by 'editor_name', title: 'Last modified by', current_column: @sort_column %>
     </th>
-    <th class="c-admin-table <%= sort_display('size', @sort_column) %>">
-      <%= sort_by 'size', title: 'Size', current_column: @sort_column %>
+    <th class="c-admin-table <%= sort_display('storage_size', @sort_column) %>">
+      <%= sort_by 'storage_size', title: 'Size', current_column: @sort_column %>
     </th>
     <th class="c-admin-table <%= sort_display('publication_date', @sort_column) %>" colspan="2">
       <%= sort_by 'publication_date', title: 'Publication Date', current_column: @sort_column %>
     </th>
   </tr>
 
-  <% resources.each do |resource| %>
-    <% identifier = resource.identifier %>
-
+  <% datasets.each do |dataset| %>
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
-        <%= link_to resource.title, show_path(id: identifier.to_s, latest: true), target: :blank %>
+        <%= link_to dataset.title, show_path(id: dataset.identifier, latest: true), target: :blank %>
       </td>
-      <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= resource.id %>">
-        <% if resource&.current_curation_activity.curation? || resource&.dataset_in_progress_editor&.id == current_user.id %>
-          <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: resource.id } %>
+      <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
+        <% if dataset.status == 'curation' || dataset.editor_id == current_user.id %>
+          <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: dataset.resource_id } %>
         <% end %>
       </td>
-      <td class="c-admin-hide-border-right" id="js-curation-state-<%= identifier.id %>">
-        <%= resource.current_curation_activity.readable_status %>
+      <td class="c-admin-hide-border-right" id="js-curation-state-<%= dataset.identifier_id %>">
+        <%= dataset.status %>
       </td>
       <td class="c-admin-hide-border-left">
-        <% if %w[admin superuser].include?(current_user.role) && resource.curatable? %>
+        <% if %w[admin superuser].include?(current_user.role) && dataset.resource_state == 'submitted' && %w[published embargoed].include?(dataset.status) %>
           <%= form_tag({ controller: '/stash_engine/admin_datasets',
-                         action: 'curation_activity_popup', id: resource.id },
+                         action: 'curation_activity_popup', id: dataset.resource_id },
                          method: :get, remote: true) do -%>
             <button class="c-admin-edit-icon" aria-label="Update status" alt="Update status">
               <i class="fa fa-pencil" aria-hidden="true"></i>
@@ -53,23 +51,28 @@
           <% end %>
         <% end %>
       </td>
-      <td><%= resource&.authors.first&.author_standard_name %></td>
-      <td><%= identifier.identifier %></td>
-      <td class="c-admin-hide-border-right" id="js-curation-activity-date-<%= identifier.id %>">
-        <%= formatted_datetime(resource.current_curation_activity.updated_at) %>
+      <td><%= dataset.author_names %></td>
+      <td><%= dataset.identifier %></td>
+      <td class="c-admin-hide-border-right" id="js-curation-activity-date-<%= dataset.identifier_id %>">
+        <%= formatted_datetime(dataset.updated_at) %>
       </td>
       <td class="c-admin-hide-border-left">
-        <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'activity_log', id: identifier.id }, method: :get) do -%>
+        <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'activity_log', id: dataset.identifier_id }, method: :get) do -%>
           <button class="c-admin-edit-icon" aria-label="View Activity Log" alt="View Activity Log">
             <i class="fa fa-clock-o" aria-hidden="true"></i>
           </button>
         <% end %>
       </td>
-      <td id="js-curation-activity-user-<%= identifier.id %>"><%= resource.editor&.name %></td>
-      <td><%= filesize(identifier.storage_size) %></td>
-      <td class="c-admin" id="js-embargo-state-<%= identifier.id %>">
-        <%= formatted_date(resource&.publication_date) %>
+      <td id="js-curation-activity-user-<%= dataset.identifier_id %>"><%= dataset.editor_name %></td>
+      <td><%= filesize(dataset.storage_size) %></td>
+      <td class="c-admin" id="js-embargo-state-<%= dataset.identifier_id %>">
+        <%= formatted_date(dataset.publication_date) %>
       </td>
     </tr>
+  <% end %>
+  <% if datasets.empty? %>
+    <tr><td colspan="8">
+      No datasets matched your search term and/or filter settings.
+    </td></tr>
   <% end %>
 </table>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_filter.html.erb
@@ -1,7 +1,9 @@
 <%= form_tag({ controller: '/stash_engine/admin_datasets', action: 'index' }, method: 'get', id: 'filter_form' ) do -%>
   <div class="c-horizontal-form__input--filter-by">Filter by:</div>
-  <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
-                 class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>
+  <% if current_user.superuser? %>
+    <%= select_tag(:tenant, options_for_select( [['Institution', '']] + institution_select, params[:tenant]),
+                   class: 'c-horizontal-form__input', onchange: "this.form.submit();" ) %>
+  <% end %>
   <%= select_tag(:curation_status, options_for_select( [['Status', '']] + status_select, params[:curation_status]),
                  class: 'c-horizontal-form__input--status', onchange: "this.form.submit();" ) %>
   <% if @publications.any? %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.csv.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.csv.erb
@@ -1,13 +1,13 @@
 <%= "Title,Status,Author,DOI,Last modified,Last modified by,Size,Publication date" %>
-<% @resources.each do |resource| -%>
+<% @datasets.each do |resource| -%>
 <%
     row = [ resource&.title || '[no title set]',
-            resource&.current_curation_status,
-            resource&.user&.name,
-            resource.identifier.identifier,
-            formatted_datetime(resource&.current_curation_activity&.updated_at),
-            resource&.current_curation_activity&.user&.name,
-            resource.identifier.storage_size,
+            resource&.status,
+            resource&.author_names,
+            resource.identifier,
+            formatted_datetime(resource&.updated_at),
+            resource&.editor_name,
+            resource.storage_size,
             formatted_datetime(resource&.publication_date)
     ]
 -%><%= row.to_csv(row_sep: nil).html_safe %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/index.html.erb
@@ -8,12 +8,10 @@
   <%= render partial: 'search' %>
   <%= render partial: 'filter' %>
 
-  <p>Note: if no filters are set above the list of datasets is restricted to ones with a status of 'Curation', 'Submitted' and 'Author Action Required'.</p>
-
-  <%= render partial: 'datasets_table', locals: { resources: @resources } %>
+  <%= render partial: 'datasets_table', locals: { datasets: @datasets } %>
 
   <div class="c-space-paginator">
-    <%= paginate @resources, params: { page_size: @page_size, show_all: false } %>
+    <%= paginate @datasets, params: { page_size: @page_size, show_all: false } %>
   </div>
 
   <div>


### PR DESCRIPTION
For ticket: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/415

- Created new `StashEngine::AdminDatasets::CurationTableRow` model. It is not a normal active record model and does not persist data to the DB. It handles the SQL Query (search, filter, sort) and provides access to elements of Resource, Identifier, InternalDatum, ResourceState, CurationActivity, Authors, User in one model.
- Updated the ERBs used to display the data to work with the new model
- Removed all of the `build_table` code from the controller and updated it to use the new model
- The Author column on the page now lists ALL author last names instead of just the first one. 
- Updated the search logic to do a SQL `MATCH` and a `LIKE` against the title
- Updated the table to display a 'No records found' message when the search/filter settings find no record
- Updated the filter to hide the tenant selector if the use is not a superuser
- Updated tests