### PR TITLE
Fixes for the publication updater page

### DIFF
--- a/stash_engine/app/controllers/stash_engine/publication_updater_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/publication_updater_controller.rb
@@ -12,9 +12,10 @@ module StashEngine
 
     # the admin datasets main page showing users and stats, but slightly different in scope for superusers vs tenant admins
     def index
-      proposed_changes = StashEngine::ProposedChange.where(approved: false, rejected: false)
-      @resources = StashEngine::Resource.latest_per_dataset.where(identifier_id: proposed_changes.map(&:identifier_id))
+      proposed_changes = StashEngine::ProposedChange.includes(identifier: :resources)
+        .joins(identifier: :resources).where(approved: false, rejected: false)
       @proposed_changes = proposed_changes.order(@sort_column.order).page(@page).per(@page_size)
+      @resources = StashEngine::Resource.latest_per_dataset.where(identifier_id: @proposed_changes.map(&:identifier_id))
     end
 
     def update
@@ -47,10 +48,10 @@ module StashEngine
     def setup_ds_sorting
       sort_table = SortableTable::SortTable.new(
         [sort_column_definition('title', 'stash_engine_proposed_changes', %w[title]),
-         sort_column_definition('publiction_name', 'stash_engine_proposed_changes', %w[publiction_name]),
-         sort_column_definition('publiction_issn', 'stash_engine_proposed_changes', %w[publiction_issn]),
-         sort_column_definition('publiction_doi', 'stash_engine_proposed_changes', %w[publiction_doi]),
-         sort_column_definition('publiction_date', 'stash_engine_proposed_changes', %w[publiction_date]),
+         sort_column_definition('publication_name', 'stash_engine_proposed_changes', %w[publication_name]),
+         sort_column_definition('publication_issn', 'stash_engine_proposed_changes', %w[publication_issn]),
+         sort_column_definition('publication_doi', 'stash_engine_proposed_changes', %w[publication_doi]),
+         sort_column_definition('publication_date', 'stash_engine_proposed_changes', %w[publication_date]),
          sort_column_definition('authors', 'stash_engine_proposed_changes', %w[authors]),
          sort_column_definition('provenance', 'stash_engine_proposed_changes', %w[provenance]),
          sort_column_definition('score', 'stash_engine_proposed_changes', %w[score])]

--- a/stash_engine/app/helpers/stash_engine/publication_updater_helper.rb
+++ b/stash_engine/app/helpers/stash_engine/publication_updater_helper.rb
@@ -29,7 +29,7 @@ module StashEngine
     def fetch_related_identifier_metadata(resource:, related_identifier_type:, relation_type:)
       return nil unless resource.present? && related_identifier_type.present? && relation_type.present?
       resource.related_identifiers.where(related_identifier_type: related_identifier_type,
-                                         relation_type: relation_type).first&.value || 'Not available'
+                                         relation_type: relation_type).first&.related_identifier || 'Not available'
     end
 
     def existing_authors(resource:)

--- a/stash_engine/app/views/stash_engine/publication_updater/index.html.erb
+++ b/stash_engine/app/views/stash_engine/publication_updater/index.html.erb
@@ -15,17 +15,17 @@
         <%= sort_by 'title', title: 'Title', current_column: @sort_column %>
       </th>
       <th class="c-proposed-change-table__column-small">&nbsp;</th>
-      <th class="c-admin-table <%= sort_display('publiction_name', @sort_column) %> c-proposed-change-table__column-small">
-        <%= sort_by 'publiction_name', title: 'Publication', current_column: @sort_column %>
+      <th class="c-admin-table <%= sort_display('publication_name', @sort_column) %> c-proposed-change-table__column-small">
+        <%= sort_by 'publication_name', title: 'Publication', current_column: @sort_column %>
       </th>
-      <th class="c-admin-table <%= sort_display('publiction_issn', @sort_column) %> c-proposed-change-table__column-small">
-        <%= sort_by 'publiction_issn', title: 'ISSN', current_column: @sort_column %>
+      <th class="c-admin-table <%= sort_display('publication_issn', @sort_column) %> c-proposed-change-table__column-small">
+        <%= sort_by 'publication_issn', title: 'ISSN', current_column: @sort_column %>
       </th>
-      <th class="c-admin-table <%= sort_display('publiction_doi', @sort_column) %> c-proposed-change-table__column">
-        <%= sort_by 'publiction_doi', title: 'DOI', current_column: @sort_column %>
+      <th class="c-admin-table <%= sort_display('publication_doi', @sort_column) %> c-proposed-change-table__column">
+        <%= sort_by 'publication_doi', title: 'DOI', current_column: @sort_column %>
       </th>
-      <th class="c-admin-table <%= sort_display('publiction_date', @sort_column) %> c-proposed-change-table__column-small">
-        <%= sort_by 'publiction_date', title: 'Published', current_column: @sort_column %>
+      <th class="c-admin-table <%= sort_display('publication_date', @sort_column) %> c-proposed-change-table__column-small">
+        <%= sort_by 'publication_date', title: 'Published', current_column: @sort_column %>
       </th>
       <th class="c-admin-table <%= sort_display('authors', @sort_column) %> c-proposed-change-table__column-medium">
         <%= sort_by 'authors', title: 'Authors', current_column: @sort_column %>


### PR DESCRIPTION
For tickets: https://github.com/CDL-Dryad/dryad-product-roadmap/issues/412 and https://github.com/CDL-Dryad/dryad-product-roadmap/issues/427

- Fixed bug that was referencing the wrong field name in pub updater helper
- Fixed typos in sort names
- Tweaked load order so that it only loads the latest_resource data for the records that will be displayed on the page (after kaminari)