### PR TITLE
Fix for logging year in COUNTER

### DIFF
--- a/stash_engine/app/models/stash_engine/counter_logger.rb
+++ b/stash_engine/app/models/stash_engine/counter_logger.rb
@@ -53,7 +53,7 @@ module StashEngine
         resource.try(:stash_version).try(:version),
         '', # - other id
         resource.try(:identifier).try(:target), # The landing page url with correct domain and all
-        resource.publication_date
+        resource.publication_date&.year || Time.new.year
       ]
     end
 


### PR DESCRIPTION
Super tiny fix for logging, the last field should be year of publication and required and not a date.  This will output a year.  Seems like the log format broke from this.