### PR TITLE
Fix for length error with no author names.

### DIFF
--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -53,7 +53,7 @@
         <% end %>
       </td>
       <td>
-        <% if dataset.author_names.length > 50 %>
+        <% if (dataset&.author_names&.length || 0) > 50 %>
           <%= "#{dataset.author_names[0..49]} ..." %>
         <% else %>
           <%= dataset.author_names %>


### PR DESCRIPTION
Super simple fix for some author error if it's nil or name is nil.