### PR TITLE
fix for bug with urls to dataset landing pages on curation page

### DIFF
--- a/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -8,7 +8,7 @@ module StashEngine
     class CurationTableRow
 
       attr_reader :publication_name
-      attr_reader :identifier_id, :identifier, :storage_size, :search_words
+      attr_reader :identifier_id, :identifier, :qualified_identifier, :storage_size, :search_words
       attr_reader :resource_id, :title, :publication_date, :tenant_id
       attr_reader :resource_state_id, :resource_state
       attr_reader :curation_activity_id, :status, :updated_at
@@ -18,7 +18,7 @@ module StashEngine
 
       SELECT_CLAUSE = <<-SQL
         SELECT seid.value,
-          sei.id, sei.identifier, sei.storage_size, sei.search_words,
+          sei.id, sei.identifier, CONCAT(LOWER(sei.identifier_type), ':', sei.identifier), sei.storage_size, sei.search_words,
           ser.id, ser.title, ser.publication_date, ser.tenant_id,
           sers.id, sers.resource_state,
           seca.id, seca.status, seca.updated_at,
@@ -48,27 +48,28 @@ module StashEngine
 
       # rubocop:disable Metrics/AbcSize
       def initialize(result)
-        return unless result.is_a?(Array) && result.length >= 18
+        return unless result.is_a?(Array) && result.length >= 19
 
         # Convert the array of results into attribute values
         @publication_name = result[0]
         @identifier_id = result[1]
         @identifier = result[2]
-        @storage_size = result[3]
-        @search_words = result[4]
-        @resource_id = result[5]
-        @title = result[6]
-        @publication_date = result[7]
-        @tenant_id = result[8]
-        @resource_state_id = result[9]
-        @resource_state = result[10]
-        @curation_activity_id = result[11]
-        @status = result[12]
-        @updated_at = result[13]
-        @editor_id = result[14]
-        @editor_name = result[15..16].join(', ')
-        @author_names = result[17]
-        @relevance = result.length > 18 ? result[18] : nil
+        @qualified_identifier = result[3]
+        @storage_size = result[4]
+        @search_words = result[5]
+        @resource_id = result[6]
+        @title = result[7]
+        @publication_date = result[8]
+        @tenant_id = result[9]
+        @resource_state_id = result[10]
+        @resource_state = result[11]
+        @curation_activity_id = result[12]
+        @status = result[13]
+        @updated_at = result[14]
+        @editor_id = result[15]
+        @editor_name = result[16..17].join(', ')
+        @author_names = result[18]
+        @relevance = result.length > 19 ? result[19] : nil
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -30,7 +30,7 @@
   <% datasets.each do |dataset| %>
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
-        <%= link_to dataset.title, show_path(id: dataset.identifier, latest: true), target: :blank %>
+        <%= link_to dataset.title, show_path(id: dataset.qualified_identifier, latest: true), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
         <% if dataset.status == 'curation' || dataset.editor_id == current_user.id %>


### PR DESCRIPTION
new curation table query was just retrieving `stash_engine_identifiers.identifier` from the DB for the url to the landing page. The `StashEngine::Resource` has a method on it, `identifier_str` that appends the `stash_engine_identifiers.identifier_type` to the identifier. Since this new query does not use generate the whole ActiveRecord model hierarchy we have just added some extra SQL to create the `qualified_identifier` (e.g. doi:10.5072/FK2VX0FH5Z)