### PR TITLE
ORCID omniauth starting URL needs to be a POST, not a GET

### DIFF
--- a/stash_engine/app/views/stash_engine/landing/_orcid_invite.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_orcid_invite.html.erb
@@ -4,7 +4,7 @@
 
   <p style="text-align: center;">
     <%= link_to "Connect your ORCID iD", "/stash/auth/orcid?#{{invitation: params[:invitation], identifier_id: identifier_id }.to_param}",
-                class: "js-add_my_Orcid_ID t-describe__add-button o-button__connect-orcid" %>
+                class: "js-add_my_Orcid_ID t-describe__add-button o-button__connect-orcid", method: :post %>
   </p>
 
 </div>


### PR DESCRIPTION
This "button" (actually link) was failing with an invalid path.  Changing to a POST fixes it since that is the way omniauth requires the route to be.

Fix for this ticket. https://github.com/CDL-Dryad/dryad-product-roadmap/issues/442