### PR TITLE
Updates for LinkOut file generation

### DIFF
--- a/stash_engine/db/migrate/20190906084410_change_value_to_long_text_on_stash_engine_external_references.rb
+++ b/stash_engine/db/migrate/20190906084410_change_value_to_long_text_on_stash_engine_external_references.rb
@@ -1,5 +1,5 @@
 class ChangeValueToLongTextOnStashEngineExternalReferences < ActiveRecord::Migration
   def change
-    add_column :stash_engine_external_references, :value, :longtext
+    change_column :stash_engine_external_references, :value, :longtext
   end
 end

--- a/stash_engine/db/migrate/20190906084410_change_value_to_long_text_on_stash_engine_external_references.rb
+++ b/stash_engine/db/migrate/20190906084410_change_value_to_long_text_on_stash_engine_external_references.rb
@@ -1,0 +1,5 @@
+class ChangeValueToLongTextOnStashEngineExternalReferences < ActiveRecord::Migration
+  def change
+    add_column :stash_engine_external_references, :value, :longtext
+  end
+end

--- a/stash_engine/lib/stash/link_out/helper.rb
+++ b/stash_engine/lib/stash/link_out/helper.rb
@@ -77,14 +77,12 @@ module LinkOut
       #    17:0: ERROR: No declaration for element Base"
       #    18:0: ERROR: No declaration for element Rule"
       #    19:0: ERROR: No declaration for element SubjectType"
-      true
-
       doc = Nokogiri::XML::Document.parse(File.read(xml_file))
       dtd = Nokogiri::XML::DTD.new(doc.internal_subset.name, Nokogiri::XML::Document.parse(File.read(dtd_file)))
       return true if dtd.validate(doc).empty?
 
       p "      ERROR! #{xml_file} does not conform to the XML schema defined in: #{dtd_file}:"
-      dtd.validate(doc).each { |err| p "        #{err.to_s}" }
+      dtd.validate(doc).each { |err| p "        #{err}" }
       false
     end
 

--- a/stash_engine/lib/stash/link_out/helper.rb
+++ b/stash_engine/lib/stash/link_out/helper.rb
@@ -79,13 +79,13 @@ module LinkOut
       #    19:0: ERROR: No declaration for element SubjectType"
       true
 
-      # doc = Nokogiri::XML::Document.parse(File.read(xml_file))
-      # dtd = Nokogiri::XML::DTD.new(doc.internal_subset.name, Nokogiri::XML::Document.parse(File.read(dtd_file)))
+      doc = Nokogiri::XML::Document.parse(File.read(xml_file))
+      dtd = Nokogiri::XML::DTD.new(doc.internal_subset.name, Nokogiri::XML::Document.parse(File.read(dtd_file)))
+      return true if dtd.validate(doc).empty?
 
-      # return true if dtd.validate(doc).empty?
-      # p "      ERROR! #{xml_file} does not conform to the XML schema defined in: #{dtd_file}:"
-      # dtd.validate(doc).each { |err| p "        #{err.to_s}" }
-      # false
+      p "      ERROR! #{xml_file} does not conform to the XML schema defined in: #{dtd_file}:"
+      dtd.validate(doc).each { |err| p "        #{err.to_s}" }
+      false
     end
 
   end

--- a/stash_engine/lib/stash/link_out/pubmed_sequence_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_sequence_service.rb
@@ -25,7 +25,7 @@ module LinkOut
       @root_url = Rails.application.routes.url_helpers.root_url.freeze
       @file_counter = 1
 
-      @schema = 'http://www.ncbi.nlm.nih.gov/entrez/linkout/doc/LinkOut.dtd'
+      @schema = 'https://www.ncbi.nlm.nih.gov/projects/linkout/doc/LinkOut.dtd'
       @links_file = 'sequencelinkout[nbr].xml'
       @max_nodes_per_file = 50_000
     end

--- a/stash_engine/lib/stash/link_out/pubmed_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_service.rb
@@ -25,7 +25,7 @@ module LinkOut
       @ftp = APP_CONFIG.link_out.pubmed
       @root_url = Rails.application.routes.url_helpers.root_url.freeze
 
-      @schema = 'http://www.ncbi.nlm.nih.gov/entrez/linkout/doc/LinkOut.dtd'
+      @schema = 'https://www.ncbi.nlm.nih.gov/projects/linkout/doc/LinkOut.dtd'
       @links_file = 'pubmedlinkout.xml'
       @provider_file = 'providerinfo.xml'
     end

--- a/stash_engine/lib/tasks/link_out.rake
+++ b/stash_engine/lib/tasks/link_out.rake
@@ -103,7 +103,12 @@ namespace :link_out do
         next unless external_ref.value_changed?
 
         p "    found #{v.length} identifiers for #{k}"
-        external_ref.save
+        begin
+          external_ref.save
+        rescue Exception => e
+          p "    ERROR: #{e.message} ... skipping update for #{data.identifier_id}"
+          next
+        end
       end
       sleep(1) # The NCBI API has a threshold for how many times we can hit it
     end

--- a/stash_engine/lib/tasks/link_out.rake
+++ b/stash_engine/lib/tasks/link_out.rake
@@ -105,7 +105,7 @@ namespace :link_out do
         p "    found #{v.length} identifiers for #{k}"
         begin
           external_ref.save
-        rescue Exception => e
+        rescue StandardError => e
           p "    ERROR: #{e.message} ... skipping update for #{data.identifier_id}"
           next
         end


### PR DESCRIPTION
- Discovered that some of the datasets were blowing out the MySQL TEXT field size on the `stash_engine_external_reference` table that stores the GenBank sequence ids! So converting the field to LONGTEXT (one dataset on stage had over 100k sequences 😱 .
- Updated the DTD location and enabled the DTD validation code (the old linkout DTD did not validate)
- Added rescue block so that the Genbank Sequence will continue on if one of the records causes an error