### PR TITLE
Tweak pub updater

### DIFF
--- a/stash_datacite/app/models/stash_datacite/proposed_change.rb
+++ b/stash_datacite/app/models/stash_datacite/proposed_change.rb
@@ -11,10 +11,9 @@ module StashEngine
     def ==(other)
       return false unless other.present? && other.is_a?(StashEngine::ProposedChange)
 
-      other.identifier_id == identifier_id && other.authors == authors && other.provenance == provenance &&
-        other.publication_date == publication_date && other.publication_issn == publication_issn &&
-        other.publication_doi == publication_doi && other.publication_name == publication_name &&
-        other.title == title
+      other.identifier_id == identifier_id && other.provenance == provenance &&
+        other.publication_issn == publication_issn && other.publication_doi == publication_doi &&
+        other.publication_name == publication_name && other.title == title
     end
     # rubocop:enable Metrics/CyclomaticComplexity
 

--- a/stash_datacite/lib/stash/import/crossref.rb
+++ b/stash_datacite/lib/stash/import/crossref.rb
@@ -53,13 +53,7 @@ module Stash
         def from_proposed_change(proposed_change:)
           return new(resource: nil, crossref_json: {}) unless proposed_change.is_a?(StashEngine::ProposedChange)
           identifier = StashEngine::Identifier.find(proposed_change.identifier_id)
-          if proposed_change.publication_date.present?
-            date_parts = [proposed_change.publication_date.year, proposed_change.publication_date.month,
-                          proposed_change.publication_date.day]
-          end
           message = {
-            'author' => JSON.parse(proposed_change.authors),
-            'published-online' => { 'date-parts' => date_parts },
             'DOI' => proposed_change.publication_doi,
             'publisher' => proposed_change.publication_name,
             'title' => [proposed_change.title],

--- a/stash_engine/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
+++ b/stash_engine/app/views/stash_engine/publication_updater/_proposed_metadata.html.erb
@@ -16,14 +16,8 @@
 <%= render_column(old_val: existing_pubname, new_val: proposed_change.publication_name).html_safe %>
 <%= render_column(old_val: existing_pubissn, new_val: proposed_change.publication_issn).html_safe %>
 <%= render_column(old_val: existing_pubdoi, new_val: proposed_change.publication_doi).html_safe %>
-<%= render_column(
-  old_val: formatted_date(resource.publication_date),
-  new_val: formatted_date(proposed_change.publication_date)
-).html_safe %>
-<%= render_column(
-  old_val: existing_authors(resource: resource),
-  new_val: proposed_authors(json: proposed_change.authors)
-).html_safe %>
+<td><%= formatted_date(proposed_change.publication_date).present? ? formatted_date(proposed_change.publication_date) : 'Not available' %></td>
+<td><%= proposed_authors(json: proposed_change.authors).html_safe %></td>
 
 <td class="c-proposed-change-table__column-centered" title="Dryad score (<%= proposed_change.provenance.capitalize %> score)">
   <%= proposed_change.score&.round(2) %><br>(<%= proposed_change.provenance_score&.round(2) || 'DOI match' %>)


### PR DESCRIPTION
Curators asked for the following changes to the Publication Updater screen:
1) the proposed publication date should never overwrite the dataset publication date because the proposed publication date is the 'Journal' publication date
2) the proposed authors should never overwrite the existing authors.

Removed the code that was including those data elements from the update and also updated the UI to no longer display those elements with a blue background and arrow