### PR TITLE
Update the name of "old" Dryad

### DIFF
--- a/stash_engine/spec/config/app_config.yml
+++ b/stash_engine/spec/config/app_config.yml
@@ -6,7 +6,7 @@ test:
   submission_bc_emails: ["alan.smithee@example.edu"]
   contact_email: ["contact1@example.edu", "contact2@example.edu"]
   old_dryad_access_token: "this-is-not-a-real-token"
-  old_dryad_url: http://api.datadryad.org
+  old_dryad_url: http://v1.datadryad.org
   payments:
     service: stripe
     key: travis_test_key


### PR DESCRIPTION
Update the name to point to the long-term production server, rather than the "api" address which may be rerouted.