### PR TITLE
Fix embargo updater so that it does the right thing

### DIFF
--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -551,9 +551,10 @@ module StashEngine
       current_curation_activity.present? && (current_curation_activity.published? || current_curation_activity.embargoed?)
     end
 
-    # this is a query for the publication updating on a cron, but putting here so we can test more easily unlike the
-    def self.needs_publishing
-
+    # this is a query for the publication updating on a cron, but putting here so we can test the query more easily
+    def self.need_publishing
+      # submitted to merritt, curation embargoed, past publication date
+      all.submitted.with_visibility(states: %w[embargoed]).where('stash_engine_resources.publication_date < ?', Time.now)
     end
 
     # -----------------------------------------------------------

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -551,6 +551,11 @@ module StashEngine
       current_curation_activity.present? && (current_curation_activity.published? || current_curation_activity.embargoed?)
     end
 
+    # this is a query for the publication updating on a cron, but putting here so we can test more easily unlike the
+    def self.needs_publishing
+
+    end
+
     # -----------------------------------------------------------
     # editor
 

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -94,7 +94,7 @@ namespace :identifiers do
           resource_id: r[0],
           user_id: r[2],
           status: 'embargoed',
-          note: 'Embargo Datasets CRON - publiction date has not yet been reached, changing status to `embargo`'
+          note: 'Embargo Datasets CRON - publication date has not yet been reached, changing status to `embargo`'
         )
       rescue StandardError => e
         p "    Exception! #{e.message}"
@@ -107,29 +107,16 @@ namespace :identifiers do
   task publish_datasets: :environment do
     now = Time.now
     p "Publishing resources whose publication_date <= '#{now}'"
-    query = <<-SQL
-      SELECT ser.id, ser.identifier_id, seca.user_id
-      FROM stash_engine_resources ser
-        LEFT OUTER JOIN stash_engine_identifiers sei ON ser.identifier_id = sei.id
-        INNER JOIN (SELECT MAX(r2.id) r_id FROM stash_engine_resources r2 GROUP BY r2.identifier_id) j1 ON j1.r_id = ser.id
-        LEFT OUTER JOIN (SELECT ca2.resource_id, MAX(ca2.id) latest_curation_activity_id FROM stash_engine_curation_activities ca2 GROUP BY ca2.resource_id) j3 ON j3.resource_id = ser.id
-        LEFT OUTER JOIN stash_engine_curation_activities seca ON seca.id = j3.latest_curation_activity_id
-      WHERE seca.status != 'published' AND ser.publication_date <=
-    SQL
 
-    query += " '#{now.strftime('%Y-%m-%d %H:%M:%S')}'"
-    ActiveRecord::Base.connection.execute(query).each do |r|
-      begin
-        p "Publishing: Identifier: #{r[1]}, Resource: #{r[0]}"
-        StashEngine::CurationActivity.create(
-          resource_id: r[0],
-          user_id: r[2],
-          status: 'published',
-          note: 'Publish Datasets CRON - reached the publication date, changing status to `published`'
-        )
-      rescue StandardError => e
-        p "    Exception! #{e.message}"
-      end
+    resources = StashEngine::Resource.need_publishing
+
+    resources.each do |res|
+      last_cur_activity = res.curation_activities.last
+      res.curation_activities << StashEngine::CurationActivity.create(
+        user_id: last_cur_activity.user_id,
+        status: 'published',
+        note: 'Publish Datasets CRON - reached the publication date, changing status to `published`'
+      )
     end
   end
 

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -111,12 +111,17 @@ namespace :identifiers do
     resources = StashEngine::Resource.need_publishing
 
     resources.each do |res|
-      last_cur_activity = res.curation_activities.last
-      res.curation_activities << StashEngine::CurationActivity.create(
-        user_id: last_cur_activity.user_id,
-        status: 'published',
-        note: 'Publish Datasets CRON - reached the publication date, changing status to `published`'
-      )
+      begin
+        last_cur_activity = res.curation_activities.last
+        res.curation_activities << StashEngine::CurationActivity.create(
+          user_id: last_cur_activity.user_id,
+          status: 'published',
+          note: 'Publish Datasets CRON - reached the publication date, changing status to `published`'
+        )
+      rescue StandardError => e
+        # note we get errors with test data updating DOI and some of the other callbacks on publishing
+        p "    Exception! #{e.message}"
+      end
     end
   end
 

--- a/stash_engine/lib/tasks/stash_engine_tasks.rake
+++ b/stash_engine/lib/tasks/stash_engine_tasks.rake
@@ -125,7 +125,7 @@ namespace :identifiers do
           resource_id: r[0],
           user_id: r[2],
           status: 'published',
-          note: 'Publish Datasets CRON - reached the publiction date, changing status to `published`'
+          note: 'Publish Datasets CRON - reached the publication date, changing status to `published`'
         )
       rescue StandardError => e
         p "    Exception! #{e.message}"


### PR DESCRIPTION
The embargo updater was being bad and publishing anything with a publication date, whether it had been submitted to Merritt or whether the curation state was embargoed.  See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/455 .

🗞 🐕 