### PR TITLE
Adding a digit to the NOID minter default to make it 9 digits.

### DIFF
--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_code_for_geolocation_disabled.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_code_for_geolocation_disabled.html.erb
@@ -1,0 +1,23 @@
+<details class="c-fgroup" role="group">
+  <summary id="location_opener" class="o-showhide__summary c-fgroup__summary">Location Information (optional)</summary>
+  <p>Where was the data collected? Does it focus on particular locations?</p>
+  <fieldset class="c-fieldset">
+    <legend class="c-fieldset__legend">Add a point or rectangular area with lat/long coordinates</legend>
+    <div class="c-location">
+      <div class="c-location__button-group">
+        <button id="geo_point" class="js-location__point-button c-location__point-button--active">Point</button>
+        <button id="geo_box" class="js-location__box-button c-location__box-button">Bounding Box</button>
+      </div>
+
+      <%= render partial: "stash_datacite/geolocation_points/form", locals: { geolocation_point: @metadata_entry.new_geolocation_point } %>
+      <%= render partial: "stash_datacite/geolocation_boxes/form", locals: { geolocation_box: @metadata_entry.new_geolocation_box } %>
+    </div>
+  </fieldset>
+
+  <p class="t-describe__map-label">Add a point or draw a rectangle on the map</p>
+  <%= render partial: "stash_datacite/shared/map" %>
+  <div class="c-locations" role="group" aria-labelledby="c-locations__label">
+    <div class="c-locations__label" id="c-locations__label">Locations Added</div>
+    <%= render partial: "stash_datacite/shared/locations" %>
+  </div>
+</details>

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -75,27 +75,3 @@
     <%= link_to "add another related work", stash_datacite.related_identifiers_new_path( resource_id: @resource.id ), remote: :true, class: 'o-button__add' %>
     </fieldset>
   </details>
-
-  <details class="c-fgroup" role="group">
-    <summary id="location_opener" class="o-showhide__summary c-fgroup__summary">Location Information (optional)</summary>
-    <p>Where was the data collected? Does it focus on particular locations?</p>
-    <fieldset class="c-fieldset">
-      <legend class="c-fieldset__legend">Add a point or rectangular area with lat/long coordinates</legend>
-      <div class="c-location">
-        <div class="c-location__button-group">
-          <button id="geo_point" class="js-location__point-button c-location__point-button--active">Point</button>
-          <button id="geo_box" class="js-location__box-button c-location__box-button">Bounding Box</button>
-        </div>
-
-        <%= render partial: "stash_datacite/geolocation_points/form", locals: { geolocation_point: @metadata_entry.new_geolocation_point } %>
-        <%= render partial: "stash_datacite/geolocation_boxes/form", locals: { geolocation_box: @metadata_entry.new_geolocation_box } %>
-      </div>
-    </fieldset>
-
-    <p class="t-describe__map-label">Add a point or draw a rectangle on the map</p>
-    <%= render partial: "stash_datacite/shared/map" %>
-    <div class="c-locations" role="group" aria-labelledby="c-locations__label">
-      <div class="c-locations__label" id="c-locations__label">Locations Added</div>
-      <%= render partial: "stash_datacite/shared/locations" %>
-    </div>
-  </details>

--- a/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
+++ b/stash_datacite/app/views/stash_datacite/metadata_entry_pages/_metadata_entry_form.html.erb
@@ -33,7 +33,7 @@
   <p class="c-input__required-note">required fields</p>
 
   <details class="c-fgroup" role="group">
-    <summary class="o-showhide__summary c-fgroup__summary">Data Description</summary>
+    <summary class="o-showhide__summary c-fgroup__summary" id="data_description_opener">Data Description</summary>
 
     <% if @metadata_entry.subjects.empty? %>
     <%= render partial: "stash_datacite/subjects/form", locals: { subject: @metadata_entry.new_subject, resource_id: @resource.id } %>

--- a/stash_datacite/app/views/stash_datacite/peer_review/_review.html.erb
+++ b/stash_datacite/app/views/stash_datacite/peer_review/_review.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <p>By choosing this option, your dataset will be private during your related articles peer review period. You will have access to a private dataset download URL to be shared with collaborators or the journal. Your dataset will not enter curation or be published. Because we may not have the status of your related article, the default for this period is six months. Please email <a href="mail_to:<%= @help_email %>"><%= @help_email %></a> or uncheck this box at any point if your dataset is ready to enter curation.</p>
+  <p>By choosing this option, your dataset will be private during your related article's peer review period. You will have access to a private dataset download URL to be shared with collaborators or the journal. Your dataset will not enter curation or be published. Because we may not have the status of your related article, the default for this period is six months. Please email <a href="mail_to:<%= @help_email %>"><%= @help_email %></a> or uncheck this box at any point if your dataset is ready to enter curation.</p>
 
   <div>
     <%= form_for @resource, url: stash_datacite.peer_review_path, remote: true, authenticity_token: true do |f| %>

--- a/stash_engine/app/models/stash_engine/noid_state.rb
+++ b/stash_engine/app/models/stash_engine/noid_state.rb
@@ -32,7 +32,7 @@ module StashEngine
     end
 
     def self.initialize_minter
-      my_minter = Noid::Minter.new(template: '.reeeeeeee')
+      my_minter = Noid::Minter.new(template: '.reeeeeeeee')
       my_minter.seed(9281, 0)
       serialize_to_db(my_minter)
     end

--- a/stash_engine/app/views/stash_engine/dashboard/_migrate_alert.html.erb
+++ b/stash_engine/app/views/stash_engine/dashboard/_migrate_alert.html.erb
@@ -3,7 +3,7 @@
     <div class="c-migrate-banner__text">
       Are you missing data from your old Dryad or Dash account?
     </div>
-      <%= button_to 'Yes migrate my data.', auth_migrate_mail_path, method: :get, class: 'c-migrate-banner__button' %>
+      <%= button_to 'Yes, migrate my data', auth_migrate_mail_path, method: :get, class: 'c-migrate-banner__button' %>
       <%= button_to 'No', auth_migrate_done_path, method: :get, remote: true, class:  'c-migrate-banner__button' %>
     <button aria-label="close" class="js-alert__close o-button__close c-alert__close flash_button"></button>
   </div>

--- a/stash_engine/app/views/stash_engine/file_uploads/_choose_upload_method.html.erb
+++ b/stash_engine/app/views/stash_engine/file_uploads/_choose_upload_method.html.erb
@@ -1,6 +1,7 @@
 <%# locals: resource, upload_method [:files, :manifest] %>
 <h2 class="t-upload__choose-heading--active">Step 1: Choose File Upload Technique</h2>
-<p>You may upload data via two mechanisms: directly from your computer, or from a URL on an external server.
+<p>You may upload data via two mechanisms: directly from your computer, or from a URL on an external server (Box, Dropbox,
+  Google Drive, lab server).
   Please note that for this version of your submission you may only use one of these two upload mechanisms.
 </p>
 <%= render 'stash_engine/file_uploads/file_size_text' %>

--- a/stash_engine/app/views/stash_engine/pages/_why_use.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/_why_use.html.erb
@@ -37,17 +37,6 @@
 
     <div class="c-why-use__blurb">
       <div class="c-why-use__icon">
-        <i class="fa fa-trophy fa-3x fa-fw" aria-hidden="true"></i>
-      </div>
-      <div class="c-why-use__text">
-        <strong class="c-why-use__strong">Credit for your work.</strong> Get an informative landing page to facilitate re-use of your data and a citable DOI so you can get credit. Each landing page and dataset is optimized for search engines.
-      </div>
-    </div>
-
-    <div class="c-why-use__blocker"></div>
-
-    <div class="c-why-use__blurb">
-      <div class="c-why-use__icon">
         <i class="fa fa-globe fa-3x fa-fw" aria-hidden="true"></i>
       </div>
       <div class="c-why-use__text">

--- a/stash_engine/app/views/stash_engine/pages/home.html.erb
+++ b/stash_engine/app/views/stash_engine/pages/home.html.erb
@@ -7,9 +7,9 @@
 <div class="t-home__quote-search-group">
   <div class="t-home__quote o-quote">
     <div class="o-quote__quote">
-      Dryad is a community-owned resource.
+      Dryad is a community-owned resource
       <br>
-      <a href="<%= stash_url_helpers.our_community_path %>" class="o-quote__quote">Learn more about our organizational memberships.</a>
+      <a href="<%= stash_url_helpers.our_community_path %>" class="o-quote__quote">Learn more about our organizational memberships</a>
     </div>
   </div>
   <div class="t-home__search o-home-search">

--- a/stash_engine/app/views/stash_engine/shared/_footer.html.erb
+++ b/stash_engine/app/views/stash_engine/shared/_footer.html.erb
@@ -1,8 +1,7 @@
 <footer class="c-footer">
   <div class="c-footer__link-group">
     <div class="c-footer__policy-group">
-      <a href="http://www.cdlib.org/about/terms.html" class="js-nav-out">Terms of Use</a>
-      <a href="http://www.cdlib.org/about/privacy.html" class="js-nav-out">Privacy Policy</a>
+      <a href="/stash/terms#privacy" class="js-nav-out">Privacy Policy</a>
       <a href="http://www.cdlib.org/about/accessibility.html" class="js-nav-out">Accessibility Policy</a>
       <a href="<%= stash_url_helpers.terms_path %>">Terms of Service</a>
     </div>

--- a/stash_engine/spec/unit/models/noid_state_spec.rb
+++ b/stash_engine/spec/unit/models/noid_state_spec.rb
@@ -11,9 +11,9 @@ module StashEngine
         id1 = NoidState.mint
         id2 = NoidState.mint
         id3 = NoidState.mint
-        expect(id1).to eq('4qrfj6r0')
-        expect(id2).to eq('x95x69v0')
-        expect(id3).to eq('5qfttf00')
+        expect(id1).to eq('4qrfj6q5t')
+        expect(id2).to eq('x95x69pcr')
+        expect(id3).to eq('5qfttdz10')
       end
     end
   end


### PR DESCRIPTION
This just adds a digit by default to the minter so it's 9 digits long.  I saw while running counter stats over the weekend that Dryad has some that are 8 digits long even though they said that 7 digits was their longest.  This is to prevent DOI collisions with any existing items.