### PR TITLE
Fixes curation errors because of strip & misc nil errors

### DIFF
--- a/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
+++ b/stash_datacite/app/controllers/stash_datacite/publications_controller.rb
@@ -41,9 +41,9 @@ module StashDatacite
         return
       end
       return if params[:internal_datum][:publication].blank? # keeps the default fill-in message
-      return if @pub_issn.blank?
-      return if @msid.blank?
-      my_url = "#{APP_CONFIG.old_dryad_url}/api/v1/organizations/#{CGI.escape(@pub_issn.value)}/manuscripts/#{CGI.escape(@msid.value)}"
+      return if @pub_issn&.value.blank?
+      return if @msid&.value.blank?
+      my_url = "#{APP_CONFIG.old_dryad_url}/api/v1/organizations/#{CGI.escape(@pub_issn&.value)}/manuscripts/#{CGI.escape(@msid&.value)}"
       response = HTTParty.get(my_url,
                               query: { access_token: APP_CONFIG.old_dryad_access_token },
                               headers: { 'Content-Type' => 'application/json' })

--- a/stash_datacite/app/views/stash_datacite/resources/_in_progress_line.html.erb
+++ b/stash_datacite/app/views/stash_datacite/resources/_in_progress_line.html.erb
@@ -17,7 +17,7 @@
     <%= default_date(line.updated_at) %>
   </td>
   <td>
-    <% if line.resource.dataset_in_progress_editor.id == current_user.id %>
+    <% if line.resource&.dataset_in_progress_editor&.id == current_user.id %>
       <% if line.status == 'error' %>
         Please <%= link_to 'contact us', StashEngine.app.contact_us_uri %> to fix this submission error.
       <% else %>

--- a/stash_engine/app/models/stash_engine/author.rb
+++ b/stash_engine/app/models/stash_engine/author.rb
@@ -14,10 +14,13 @@ module StashEngine
     before_save :strip_whitespace
 
     scope :names_filled, -> { where("TRIM(IFNULL(author_first_name,'')) <> '' AND TRIM(IFNULL(author_last_name,'')) <> ''") }
-    scope :primary, ->(resource_id) { where(resource_id: resource_id).where.not(author_email: nil).order(:id).first }
 
     amoeba do
       enable
+    end
+
+    def self.primary(resource_id)
+      where(resource_id: resource_id).where.not(author_email: nil).order(:id)&.first
     end
 
     # rubocop:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
@briri or @ryscher maybe one of you can take a look at this in the morning since you'll likely be in earlier than me.

Mostly fixing nil errors we got emailed about and were repeated.

The other error is that's a bad idea to include '.first' in an activerecord scope because scopes are meant to be chained so they should return a result set (ActiveRecord Relation) and not a single item.  I believe when that single item returns nil then it returns an ActiveRecord relation without eliminating any records.  I think this is intentional, but kind of confusing.  Change this scope into a method instead.

These occurred while curators will trying to publish items that didn't have any primary authors for the stripe case (the nil).  The message about identifiers was a red herring I believe.

https://github.com/CDL-Dryad/dryad-product-roadmap/issues/487





