### PR TITLE
Some minor tweaks to the LinkOut seed tasks

### DIFF
--- a/stash_engine/lib/stash/link_out/helper.rb
+++ b/stash_engine/lib/stash/link_out/helper.rb
@@ -14,10 +14,16 @@ module LinkOut
       Rails.application.routes.url_helpers.root_url.gsub(/^http:/, 'https:')
     end
 
+    def request_headers
+      {
+        'User-Agent': 'datadryad.org (contact: help@datadryad.org)',
+        'Accept': 'text/xml'
+      }
+    end
+
     # Retrieve the XML from the API (e.g. lookup Pubmed ID for a given DOI)
     def get_xml_from_api(uri, query)
-      headers = { 'Accept': 'text/xml' }
-      resp = HTTParty.get(uri, query: query, headers: headers)
+      resp = HTTParty.get(uri, query: query, headers: request_headers)
       # If we received anything but a 200 then log an error and return an empty array
       raise "Unable to connect to connect to - #{@pubmed_api}?#{query}: status: #{resp.code}" if resp.code != 200
       # Return an empty array if the response did not have any results

--- a/stash_engine/lib/tasks/link_out.rake
+++ b/stash_engine/lib/tasks/link_out.rake
@@ -119,16 +119,9 @@ namespace :link_out do
     p 'Updating Solr keywords with manuscriptNumber, pubmedID or a isSupplementTo related identifier'
     types = %w[pubmedID manuscriptNumber]
 
-    StashEngine::Identifier.all.each do |identifier|
-      datum = identifier.joins(:internal_data, resource: :related_identifiers)
-        .where('(stash_engine_internal_data.data_type IN (?) AND stash_engine_internal_data.value IS NOT NULL) \
-          OR (dcs_related_identifiers.related_identifier_type = ? AND dcs_related_identifiers.relation_type = ? AND \
-              dcs_related_identifiers.related_identifier IS NOT NULL)', types, 'doi', 'issupplementto')
-
-      if datum.any?
-        identifier.update_search_words!
-        identifier.latest_resource.submit_to_solr
-      end
+    StashEngine::Identifier.joins(:internal_data).where("stash_engine_internal_data.data_type IN (?) AND stash_engine_internal_data.value IS NOT NULL AND stash_engine_internal_data.value != ''", types).each do |identifier|
+      identifier.update_search_words!
+      identifier.latest_resource.submit_to_solr
     end
   end
 

--- a/stash_engine/lib/tasks/link_out.rake
+++ b/stash_engine/lib/tasks/link_out.rake
@@ -64,6 +64,7 @@ namespace :link_out do
 
   desc 'Seed existing datasets with PubMed Ids - WARNING: this will query the API for each dataset that has a isSupplementTo DOI!'
   task seed_pmids: :environment do
+    sleep(1) # The NCBI API has a threshold for how many times we can hit it
     p 'Retrieving Pubmed IDs for existing datasets'
     pubmed_service = LinkOut::PubmedService.new
     existing_pmids = StashEngine::Identifier.cited_by_pubmed.pluck(:id)
@@ -81,7 +82,6 @@ namespace :link_out do
 
       p "    found pubmedID, '#{pmid}', ... attaching it to '#{data.related_identifier.gsub('doi:', '')}' (identifier: #{data.identifier_id})"
       internal_datum.save
-      sleep(1)
     end
   end
 
@@ -93,6 +93,7 @@ namespace :link_out do
     existing_pmids = StashEngine::Identifier.cited_by_pubmed.where.not(id: existing_refs).pluck(:id)
     datum = StashEngine::InternalDatum.where(identifier_id: existing_pmids, data_type: 'pubmedID').order(created_at: :desc)
     datum.each do |data|
+      sleep(1) # The NCBI API has a threshold for how many times we can hit it
       p "  looking for genbank sequences for PubmedID #{data.value}"
       sequences = pubmed_sequence_service.lookup_genbank_sequences(data.value)
       next unless sequences.any?
@@ -110,7 +111,6 @@ namespace :link_out do
           next
         end
       end
-      sleep(1) # The NCBI API has a threshold for how many times we can hit it
     end
   end
 


### PR DESCRIPTION
- Moved the `sleep(1)` on the 2 link out seed tasks to the top of the loop. We were not sleeping when the pubmed api did not return anything.
- Added a `User-Agent` header to our requests to the PubMed api so that we're better citizens :)
