### PR TITLE
removed quotes from part of pubmed linkout file

### DIFF
--- a/stash_engine/lib/stash/link_out/pubmed_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_service.rb
@@ -99,7 +99,7 @@ module LinkOut
             link_base: 'dryad.pubmed.',
             icon_url: "#{@root_url}images/DryadLogo-Button.png",
             callback_base: "#{@root_url}discover?",
-            callback_rule: 'query=%22&lo.doi;%22',
+            callback_rule: 'query=&lo.doi;',
             subject_type: 'supplemental materials',
             identifiers: identifiers
           }


### PR DESCRIPTION
Our contact at PubMed asked that we remove the quotes from the callback urls portion of the linkup xml file.

She has manually corrected the file we generated today. This change will ensure that the quotes do not appear when the files are regenerated via cron (on Sundays)