### PR TITLE
Fixing edit pencils and other enhancements and bugs

### DIFF
--- a/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -32,7 +32,7 @@ module StashEngine
 
       FROM_CLAUSE = <<-SQL
           FROM stash_engine_resources ser
-          LEFT OUTER JOIN stash_engine_identifiers sei ON ser.identifier_id = sei.id
+          INNER JOIN stash_engine_identifiers sei ON ser.identifier_id = sei.id
           LEFT OUTER JOIN stash_engine_internal_data seid ON sei.id = seid.identifier_id AND seid.data_type = 'publicationName'
           LEFT OUTER JOIN stash_engine_users seu ON ser.current_editor_id = seu.id
           INNER JOIN (SELECT MAX(r2.id) r_id FROM stash_engine_resources r2 GROUP BY r2.identifier_id) j1 ON j1.r_id = ser.id

--- a/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
+++ b/stash_engine/app/models/stash_engine/admin_datasets/curation_table_row.rb
@@ -3,6 +3,8 @@
 # This is NOT an ActiveRecord model and does not persist data!!
 # This class represents a row in the Admin's Curation page. It only retrieves the information
 # necessary to populate the table on that page.
+
+# rubocop:disable Metrics/ClassLength
 module StashEngine
   module AdminDatasets
     class CurationTableRow
@@ -72,6 +74,12 @@ module StashEngine
         @relevance = result.length > 19 ? result[19] : nil
       end
       # rubocop:enable Metrics/AbcSize
+      #
+
+      # lets you get a resource when you need it and caches it
+      def resource
+        @resource ||= StashEngine::Resource.find_by(id: @resource_id)
+      end
 
       class << self
 
@@ -141,3 +149,4 @@ module StashEngine
     end
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -33,7 +33,7 @@
         <%= link_to dataset.title, show_path(id: dataset.qualified_identifier, latest: true), target: :blank %>
       </td>
       <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
-        <% if dataset.status == 'curation' || dataset.editor_id == current_user.id %>
+        <% if dataset.resource&.can_edit?(user: current_user) && dataset.resource_state == 'submitted' %>
           <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: dataset.resource_id } %>
         <% end %>
       </td>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -30,7 +30,11 @@
   <% datasets.each do |dataset| %>
     <tr class="c-lined-table__row">
       <td class="c-admin-hide-border-right">
-        <%= link_to dataset.title, show_path(id: dataset.qualified_identifier, latest: true), target: :blank %>
+        <% if dataset&.qualified_identifier %>
+            <%= link_to dataset.title, show_path(id: dataset.qualified_identifier, latest: true), target: :blank %>
+        <% else %>
+          <%= dataset.title %>
+        <% end %>
       </td>
       <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
         <% if dataset.resource&.can_edit?(user: current_user) && dataset.resource_state == 'submitted' %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -37,7 +37,7 @@
         <% end %>
       </td>
       <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
-        <%# only with permission and not being messed with or in_progress and they're the ones futzing with it, lockout concurrent editing %>
+        <%# only with permission and not being messed with or in_progress or they're the ones futzing with it and making it in progress, lockout other concurrent editing %>
         <% if (dataset.resource&.permission_to_edit?(user: current_user) && dataset.resource_state == 'submitted') ||
             (dataset.resource_state == 'in_progress' && dataset.resource.current_editor_id == current_user.id)
         %>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -37,7 +37,7 @@
         <% end %>
       </td>
       <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
-        <% if dataset.resource&.can_edit?(user: current_user) && dataset.resource_state == 'submitted' %>
+        <% if dataset.resource&.permission_to_edit?(user: current_user) && dataset.resource_state == 'submitted' %>
           <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: dataset.resource_id } %>
         <% end %>
       </td>

--- a/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
+++ b/stash_engine/app/views/stash_engine/admin_datasets/_datasets_table.html.erb
@@ -37,7 +37,10 @@
         <% end %>
       </td>
       <td class="c-admin-hide-border-left" id="js-edit-dataset-button-column-<%= dataset.resource_id %>">
-        <% if dataset.resource&.permission_to_edit?(user: current_user) && dataset.resource_state == 'submitted' %>
+        <%# only with permission and not being messed with or in_progress and they're the ones futzing with it, lockout concurrent editing %>
+        <% if (dataset.resource&.permission_to_edit?(user: current_user) && dataset.resource_state == 'submitted') ||
+            (dataset.resource_state == 'in_progress' && dataset.resource.current_editor_id == current_user.id)
+        %>
           <%= render partial: 'stash_engine/admin_datasets/edit_dataset_button', locals: { resource_id: dataset.resource_id } %>
         <% end %>
       </td>


### PR DESCRIPTION
INNER JOINING to identifier.  All imported Dash records have identifiers and all migrated Dryad content does.  Even if there is a resource without an identifier then it may not be curated because there will never be a landing page for it without a DOI.  We also have specifically excluded some resources by disconnecting them from their identifier so their landing page doesn't display or the version is excluded.

Added method to get resource for use in the curation page if it's needed (and caches it).  This will only load for items where it is used (one page full).

- If no identifier then no link to a landing page that cannot exist because an identifier is required for a landing page.

- The curators want to freely edit, so as long as it's submitted to Merritt they can edit.  Or they can go back in and re-edit something they put into an in-progress state, but not one that someone else did (lock out concurrent editing).