### PR TITLE
This is a quick hack to update temp_file_paths to current

### DIFF
--- a/stash_engine/lib/tasks/file_path_hack.rake
+++ b/stash_engine/lib/tasks/file_path_hack.rake
@@ -1,7 +1,7 @@
 namespace :file do
 
   desc 'many file_upload.temp_file_paths contain a releases directory, change to current instead until we can fix this'
-  task path_hack:  :environment do
+  task path_hack: :environment do
     StashEngine::FileUpload.where("temp_file_path LIKE '%/releases/%'").each do |fu|
       changed = fu.temp_file_path.gsub(%r{/releases/\d+/}, '/current/')
       fu.update_column(:temp_file_path, changed)

--- a/stash_engine/lib/tasks/file_path_hack.rake
+++ b/stash_engine/lib/tasks/file_path_hack.rake
@@ -1,0 +1,11 @@
+namespace :file do
+
+  desc 'many file_upload.temp_file_paths contain a releases directory, change to current instead until we can fix this'
+  task path_hack:  :environment do
+    StashEngine::FileUpload.where("temp_file_path LIKE '%/releases/%'").each do |fu|
+      changed = fu.temp_file_path.gsub(%r{/releases/\d+/}, '/current/')
+      fu.update_column(:temp_file_path, changed)
+      puts "updated: #{changed}"
+    end
+  end
+end


### PR DESCRIPTION
I'll run this occasionally to be sure the temp_file_paths are still valid even after we do new releases.  This is just a temporary hack.

Thinking about it, it may be that temp_file_path may only be used on the file upload page for keeping track of where to write chunks of a file.  If so it is less severe of a problem and will probably only break people's uploads if they're in the middle of uploading while we do a new release.