### PR TITLE
Files disappearing fix for individual file/version downloads

### DIFF
--- a/stash_datacite/.rubocop.yml
+++ b/stash_datacite/.rubocop.yml
@@ -9,6 +9,7 @@ AllCops:
     - 'spec/dummy/db/**/*'
     - 'test/dummy/db/**/*'
     - 'vendor/**/*'
+    - 'lib/tasks/embargo_fix.rake'
 
 # These files are just inherently long lists of things
 Metrics/MethodLength:

--- a/stash_datacite/lib/tasks/embargo_fix.rake
+++ b/stash_datacite/lib/tasks/embargo_fix.rake
@@ -1,3 +1,4 @@
+# rubocop:disable
 require 'stash/import/crossref'
 
 # Emgargo fix tool -- correct overly-conservative embargoes that were put in place by migration
@@ -8,66 +9,62 @@ namespace :embargo_fix do
   desc 'Do some embargo manipulation'
   task do_it: :environment do
     p 'Starting embargo correction'
-    embargo_problem_items = File.readlines("/apps/dryad/embargoIssues.txt").each do |line|
-      line.gsub!(/doi:/, "")
+    embargo_problem_items = File.readlines('/apps/dryad/embargoIssues.txt').each do |line|
+      line.gsub!(/doi:/, '')
       line.gsub!(/\s+/, '')
       p "Processing #{line}"
 
       is = StashEngine::Identifier.where(identifier: line)
-      if is.size > 0        
-        p "- found #{is.size} identifiers for #{line}"
-        is.each do |i|
-          p "  - identifier #{i.id} #{i&.identifier}"
-          rs = i.resources
-          rs.each do |r|
-            embargo_indicator = nil
-            @publishing = false
-            p "    - resource #{r.id}"
-            cas = r.curation_activities
+      next if is.empty?
+      p "- found #{is.size} identifiers for #{line}"
+      is.each do |i|
+        p "  - identifier #{i.id} #{i&.identifier}"
+        rs = i.resources
+        rs.each do |r|
+          embargo_indicator = nil
+          @publishing = false
+          p "    - resource #{r.id}"
+          cas = r.curation_activities
 
-            # verify that the embargo was set incorrectly for this item  and that it hasn't been fixed yet
-            cas.order(:id).each do |ca|
-              notestring = ca&.note
-              p "      - ca #{ca&.id} #{ca&.created_at} #{notestring}"
-              if notestring                
-                if notestring.match /package-level embargo to reflect previous file-level/
-                  p "      - ######### EMBARGO INDICATOR ##############"
-                  embargo_indicator = ca
-                end
-              end
+          # verify that the embargo was set incorrectly for this item  and that it hasn't been fixed yet
+          cas.order(:id).each do |ca|
+            notestring = ca&.note
+            p "      - ca #{ca&.id} #{ca&.created_at} #{notestring}"
+            next unless notestring
+            if /package-level embargo to reflect previous file-level/.match?(notestring)
+              p '      - ######### EMBARGO INDICATOR ##############'
+              embargo_indicator = ca
+            end
+          end
+
+          # re-process the curation activities from the beginning
+          # if a fix is needed, find the publish date, set it, and
+          # update all subsequent curation activities to be 'published'
+          next unless embargo_indicator
+          embargo_indicator.destroy # remove the indicator CurationActivity
+          embargo_indicator = nil
+
+          cas = r.curation_activities # reload the CurationActivities without the indicator
+
+          cas.order(:id).each do |ca|
+            p "      - ca #{ca&.id} #{ca&.created_at} #{ca&.note[0..30]}"
+            if ca&.note&.match /Made available in DSpace on/
+              p "      - ######### PUBLISH DATE #{ca&.created_at} ##############"
+              r.publication_date = ca&.created_at
+              r.save
+              @publishing = true
             end
 
-            # re-process the curation activities from the beginning
-            # if a fix is needed, find the publish date, set it, and
-            # update all subsequent curation activities to be 'published'
-            if embargo_indicator
-              embargo_indicator.destroy # remove the indicator CurationActivity
-              embargo_indicator = nil
-              
-              cas = r.curation_activities # reload the CurationActivities without the indicator
-                           
-              cas.order(:id).each do |ca|
-                p "      - ca #{ca&.id} #{ca&.created_at} #{ca&.note[0..30]}"
-                if ca&.note&.match /Made available in DSpace on/
-                  p "      - ######### PUBLISH DATE #{ca&.created_at} ##############"
-                  r.publication_date = ca&.created_at
-                  r.save
-                  @publishing = true
-                end
-                
-                if @publishing
-                  p "      - updating to published"
-                  if ca&.note&.match /publiction date has not yet been reached/
-                    ca.destroy
-                  else
-                    ca.status = 'published'
-                    ca.save
-                  end
-                end
-              end
-              @publishing = false
+            next unless @publishing
+            p '      - updating to published'
+            if ca&.note&.match /publiction date has not yet been reached/
+              ca.destroy
+            else
+              ca.status = 'published'
+              ca.save
             end
-          end            
+          end
+          @publishing = false
         end
       end
     end
@@ -75,4 +72,4 @@ namespace :embargo_fix do
   end
 
 end
-# rubocop:enable Metrics/BlockLength
+# rubocop:enable

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -111,7 +111,7 @@ module StashEngine
     end
 
     def latest_resource_with_public_download
-      resources.published.by_version_desc.first
+      resources.files_published.by_version_desc.first
     end
 
     def latest_downloadable_resource(user: nil)

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -109,6 +109,17 @@ module StashEngine
       latest_resource_with_public_metadata
     end
 
+    def latest_resource_with_public_download
+      resources.published.by_version_desc.first
+    end
+
+    def latest_downloadable_resource(user: nil)
+      return latest_resource_with_public_download if user.nil?
+      lr = latest_resource
+      return lr if user.id == lr.user_id || user.superuser? || (user.role == 'admin' && user.tenant_id == lr.tenant_id)
+      latest_resource_with_public_download
+    end
+
     def last_submitted_version_number
       (lsv = last_submitted_resource) && lsv.version_number
     end

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -98,6 +98,7 @@ module StashEngine
 
     # these are items that are embargoed or published and can show metadata
     def latest_resource_with_public_metadata
+      return nil if resources&.last&.curation_activities&.last&.status == 'withdrawn'
       resources.with_public_metadata.by_version_desc.first
     end
 

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -141,7 +141,14 @@ module StashEngine
                                                                             status: %w[published embargoed] })
     end
 
-    # calculates published as a published status or embargoed and past its publication date
+    scope :files_published, -> do
+      # this also depends on the publication updater to update statuses to published daily
+      joins(:curation_activities)
+          .where(stash_engine_curation_activities: { id: latest_curation_activity.values,
+                                                     status: %w[published] })
+    end
+
+    # this is METADATA published
     scope :published, -> do
       joins(:curation_activities).where('stash_engine_resources.publication_date < ?', Time.now.utc)
         .where(stash_engine_curation_activities: { id: latest_curation_activity.values,

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -144,8 +144,8 @@ module StashEngine
     scope :files_published, -> do
       # this also depends on the publication updater to update statuses to published daily
       joins(:curation_activities)
-          .where(stash_engine_curation_activities: { id: latest_curation_activity.values,
-                                                     status: %w[published] })
+        .where(stash_engine_curation_activities: { id: latest_curation_activity.values,
+                                                   status: %w[published] })
     end
 
     # this is METADATA published

--- a/stash_engine/app/views/stash_engine/landing/_files.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_files.html.erb
@@ -1,13 +1,14 @@
 <%# takes local variable of dataset_identifier and resource %>
 <% resources = dataset_identifier.resources_with_file_changes.by_version
-   resources.to_a.keep_if { |i| i.may_download?(ui_user: current_user) } %>
+   ldr = dataset_identifier.latest_downloadable_resource(user: current_user)
+   resources.to_a.keep_if { |i| i.id <= ldr.id } %>
 <% if resources.count.positive? %>
   <div class="c-sidebox">
     <h3 class="c-sidebox__heading">Data Files</h3>
     <% resources.each do |res| %>
       <details class="c-file-group" role="group">
         <summary class="o-showhide__summary c-file-group__summary">
-          <%= formatted_date(res.publication_date.present? ? res.publication_date : res.updated_at) %></summary>
+          <%= formatted_date(res.updated_at) %></summary>
         <ul class="c-file-group__list">
           <% res.current_file_uploads.each do |fu| %>
             <li>

--- a/stash_engine/app/views/stash_engine/landing/_files.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_files.html.erb
@@ -1,7 +1,16 @@
 <%# takes local variable of dataset_identifier and resource %>
-<% resources = dataset_identifier.resources_with_file_changes.by_version
-   ldr = dataset_identifier.latest_downloadable_resource(user: current_user)
-   resources.to_a.keep_if { |i| i.id <= ldr.id } %>
+<%
+  resources = dataset_identifier.resources_with_file_changes.by_version
+  ldr = dataset_identifier.latest_downloadable_resource(user: current_user)
+  resources.to_a.keep_if { |i| i.id <= ldr.id }
+
+  # this IF is for a data problem, we should never have files that were only copied from previous versions, yet we did.
+  # maybe because curators needed hacks on hacks to remove previous versions. There should always be a version when they
+  # were added.
+  if resources.empty?
+    resources = [ ldr ] if ldr.file_uploads.count.positive?
+  end
+%>
 <% if resources.count.positive? %>
   <div class="c-sidebox">
     <h3 class="c-sidebox__heading">Data Files</h3>

--- a/stash_engine/app/views/stash_engine/landing/_files.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_files.html.erb
@@ -17,7 +17,9 @@
     <% resources.each do |res| %>
       <details class="c-file-group" role="group">
         <summary class="o-showhide__summary c-file-group__summary">
-          <%= formatted_date(res.updated_at) %></summary>
+          <%= formatted_date(res.publication_date.present? && res.publication_date < Time.new ?
+                                 res.publication_date : res.updated_at) %>
+        </summary>
         <ul class="c-file-group__list">
           <% res.current_file_uploads.each do |fu| %>
             <li>

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -190,6 +190,16 @@ module StashEngine
             expect(@identifier.latest_resource_with_public_metadata).to eql(nil)
           end
 
+          it 'disallows any access if latest state is withdrawn' do
+            @res1.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res1.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'withdrawn', user: @user)
+            expect(@identifier.latest_resource_with_public_metadata).to eql(nil)
+          end
+
         end
 
         describe '#latest_viewable_resource' do
@@ -238,6 +248,46 @@ module StashEngine
             expect(@identifier.latest_viewable_resource(user: user2)).to eql(@identifier.latest_resource_with_public_metadata)
           end
         end
+
+        describe '#latest_resource_with_public_download' do
+
+          it 'finds the last download resource' do
+            @res1.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res1.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            expect(@identifier.latest_resource_with_public_download).to eql(@res2)
+          end
+
+          it 'finds published resource' do
+            @res1.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res1.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'embargoed', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            expect(@identifier.latest_resource_with_public_download).to eql(@res1)
+          end
+
+          it 'finds no published resource' do
+            @res1.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            expect(@identifier.latest_resource_with_public_metadata).to eql(nil)
+          end
+
+          it 'disallows any access if latest state is withdrawn' do
+            @res1.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res1.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res2.curation_activities << CurationActivity.create(status: 'published', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'curation', user: @user)
+            @res3.curation_activities << CurationActivity.create(status: 'withdrawn', user: @user)
+            expect(@identifier.latest_resource_with_public_metadata).to eql(nil)
+          end
+
+        end
+
       end
 
       describe '#update_search_words!' do


### PR DESCRIPTION
This was a bad interaction between suppressing versions and also overly complicated and unclear embargoing/publishing practices and versioning.

For now it assumes the last embargo/published state applies to all versions before it.

For the future we need to make this much more explicit and much less complicated.  We can address curators desire to hide versions they don't like at the same time.

The changes to ryan's migration script were rubocop autofixes but shouldn't change function.