### PR TITLE
Invoicer auto advance

### DIFF
--- a/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash_engine/lib/stash/payments/invoicer.rb
@@ -26,7 +26,6 @@ module Stash
         return unless customer_id.present?
         create_invoice_items_for_dpc(customer_id)
         invoice = create_invoice(customer_id)
-        invoice.auto_advance = true
         resource.identifier.invoice_id = invoice.id
         resource.identifier.save
         invoice.finalize_invoice
@@ -118,7 +117,10 @@ module Stash
 
       def create_invoice(customer_id)
         Stripe::Invoice.create(
+          auto_advance: 'true',
+          collection_method: 'send_invoice',
           customer: customer_id,
+          days_until_due: '30',
           description: 'Dryad deposit ' + resource.identifier.to_s + ', ' + resource.title,
           metadata: { 'curator' => curator.name }
         )
@@ -126,7 +128,7 @@ module Stash
 
       def create_customer(author)
         Stripe::Customer.create(
-          description: author.author_standard_name,
+          name: author.author_standard_name,
           email: author.author_email
         )
       end

--- a/stash_engine/lib/stash/payments/invoicer.rb
+++ b/stash_engine/lib/stash/payments/invoicer.rb
@@ -28,7 +28,7 @@ module Stash
         invoice = create_invoice(customer_id)
         resource.identifier.invoice_id = invoice.id
         resource.identifier.save
-        invoice.finalize_invoice
+        invoice.send_invoice
       end
 
       # For a journal, generate an invoice item for the DPC.
@@ -117,10 +117,10 @@ module Stash
 
       def create_invoice(customer_id)
         Stripe::Invoice.create(
-          auto_advance: 'true',
+          auto_advance: true,
           collection_method: 'send_invoice',
           customer: customer_id,
-          days_until_due: '30',
+          days_until_due: 30,
           description: 'Dryad deposit ' + resource.identifier.to_s + ', ' + resource.title,
           metadata: { 'curator' => curator.name }
         )

--- a/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
+++ b/stash_engine/spec/unit/stash/payments/invoicer_spec.rb
@@ -34,7 +34,7 @@ module Stash
         @cust_id = '9999'
         fake_invoice_item = OpenStruct.new(customer: @cust_id, amount: '99.99', currency: 'usd', description: 'Data Processing Charge')
         fake_invoice = OpenStruct.new(customer: @cust_id, description: 'Dryad deposit',
-                                      metadata: { curator: 'The Curator' }, finalize_invoice: 'STRIPE1234')
+                                      metadata: { curator: 'The Curator' }, send_invoice: 'STRIPE1234')
         fake_customer = OpenStruct.new(id: @cust_id, email: @author.author_email, description: @author.author_standard_name)
 
         @invoicer = Invoicer.new(resource: @resource, curator: @curator)


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/510

Corrects some issues with the Stripe invoices:
- set the `auto_advance` property using the correct mechanism
- force invoices to be emailed using `send_invoice` instead of `finalize_invoice`
- put the customer's name in `Customer.name` instead of description

Unfortunately, since Stripe's testmode doesn't send email, the only way to truly test this is to create real invoices, and then go into Stripe and void them. I have done this, but boo to Stripe.