### PR TITLE
Populating and calculating view for submitted versions

### DIFF
--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -192,12 +192,15 @@ module StashEngine
       return if %w[withdrawn embargoed].include?(status)
 
       # find out if there were not file changes since last publication and reset file_view, if so.
-      unchanged = true
+      changed = false # want to see that none are changed
       resource.identifier.resources.reverse_each do |res|
         break if res.id != resource.id && res&.current_curation_activity&.status == 'published' # break once reached previous published
-        unchanged &&= res.files_unchanged?
+        if res.files_changed?
+          changed = true
+          break
+        end
       end
-      resource.update_column(:file_view, false) if unchanged # if nothing changed between previous published and this, don't view same files again
+      resource.update_column(:file_view, false) unless changed # if nothing changed between previous published and this, don't view same files again
     end
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -66,6 +66,8 @@ module StashEngine
     after_create :email_orcid_invitations,
                  if: proc { |ca| ca.published? && latest_curation_status_changed? && !resource.skip_emails }
 
+    after_create :update_publication_flags, if: proc { |ca| %w[published embargoed withdrawn].include?(ca.status) }
+
     # Class methods
     # ------------------------------------------
     # Translates the enum value to a human readable status
@@ -171,6 +173,33 @@ module StashEngine
       end
     end
     # rubocop:enable Metrics/AbcSize
+
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def update_publication_flags
+      case status
+      when 'withdrawn'
+        resource.update_columns(meta_view: false, file_view: false)
+      when 'embargoed'
+        resource.update_columns(meta_view: true, file_view: false)
+      when 'published'
+        resource.update_columns(meta_view: true, file_view: true)
+      end
+
+      return if resource&.identifier.nil?
+
+      resource.identifier.update_column(:pub_state, status)
+
+      return if %w[withdrawn embargoed].include?(status)
+
+      # find out if there were not file changes since last publication and reset file_view, if so.
+      unchanged = true
+      resource.identifier.resources.reverse_each do |res|
+        break if res.id != resource.id && res&.current_curation_activity&.status == 'published' # break once reached previous published
+        unchanged &&= res.files_unchanged?
+      end
+      resource.update_column(:file_view, false) if unchanged # if nothing changed between previous published and this, don't view same files again
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity
 
     # Helper methods
     # ------------------------------------------

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -288,7 +288,11 @@ module StashEngine
     end
 
     def files_unchanged?
-      file_uploads.where(file_state: %w[created deleted]).count < 1
+      !files_changed?
+    end
+
+    def files_changed?
+      file_uploads.where(file_state: %w[created deleted]).count.positive?
     end
 
     # ------------------------------------------------------------

--- a/stash_engine/app/models/stash_engine/resource.rb
+++ b/stash_engine/app/models/stash_engine/resource.rb
@@ -287,6 +287,10 @@ module StashEngine
       file_uploads.where(url: url).where(file_state: 'created').where(status_code: 200).count > 0
     end
 
+    def files_unchanged?
+      file_uploads.where(file_state: %w[created deleted]).count < 1
+    end
+
     # ------------------------------------------------------------
     # Special merritt download URLs
 

--- a/stash_engine/db/migrate/20190926213516_add_public_view_to_resources.rb
+++ b/stash_engine/db/migrate/20190926213516_add_public_view_to_resources.rb
@@ -1,0 +1,7 @@
+class AddPublicViewToResources < ActiveRecord::Migration
+  def change
+    # these are for public metadata view and public file view for this version
+    add_column :stash_engine_resources, :meta_view, :boolean, default: false
+    add_column :stash_engine_resources, :file_view, :boolean, default: false
+  end
+end

--- a/stash_engine/db/migrate/20190926214109_add_pub_state_to_identifier.rb
+++ b/stash_engine/db/migrate/20190926214109_add_pub_state_to_identifier.rb
@@ -1,0 +1,12 @@
+class AddPubStateToIdentifier < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      ALTER TABLE stash_engine_identifiers ADD pub_state
+        enum('embargoed', 'published', 'withdrawn', 'unpublished');
+    SQL
+  end
+
+  def down
+    remove_column :stash_engine_identifiers, :pub_state, :enum
+  end
+end

--- a/stash_engine/lib/tasks/versioning.rake
+++ b/stash_engine/lib/tasks/versioning.rake
@@ -1,0 +1,20 @@
+namespace :versioning do
+  desc 'write sensible versioning display flags and current dataset status'
+  task set_view_versions: :environment do
+    identifiers = StashEngine::Identifier.all
+    puts 'Processing . . .'
+    identifiers.each_with_index do |identifier, idx|
+      # show some progress, so we know something is happening, but don't spam us with all the identifier updates
+      puts "Processing #{idx + 1} of #{identifiers.count}" if (idx + 1) % 100 == 0
+
+      begin
+        identifier.update(pub_state: identifier.calculated_pub_state) # set the publishing state explicitly based on pub history
+        identifier.fill_resource_view_flags
+      rescue StandardError => e
+        # this is so we can at least output which identifier caused this exception
+        puts "#{identifier.identifier} caused error #{e}"
+        raise e
+      end
+    end
+  end
+end

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -1,4 +1,5 @@
 require 'db_spec_helper'
+require 'byebug'
 
 module StashEngine
   describe CurationActivity do
@@ -71,6 +72,7 @@ module StashEngine
         allow_any_instance_of(Stash::Doi::IdGen).to receive(:update_identifier_metadata).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:new).and_return(true)
         allow_any_instance_of(Stash::Payments::Invoicer).to receive(:charge_user_via_invoice).and_return(true)
+        # allow_any_instance_of(StashEngine::CurationActivity).to receive(:update_publication_flags).and_return(true)
       end
 
       context :update_solr do
@@ -227,6 +229,14 @@ module StashEngine
           @ca.save
         end
 
+      end
+
+      context :update_publication_flags do
+
+        it 'does something' do
+          puts 'hi'
+          byebug
+        end
       end
 
     end

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -233,9 +233,35 @@ module StashEngine
 
       context :update_publication_flags do
 
-        it 'does something' do
-          puts 'hi'
-          byebug
+        it 'sets flags for embargo' do
+          @resource.curation_activities << CurationActivity.create(status: 'embargoed', user: @user)
+          @identifier.reload
+          @resource.reload
+          expect(@identifier.pub_state).to eq('embargoed')
+          expect(@resource.meta_view).to eq(true)
+          expect(@resource.file_view).to eq(false)
+        end
+
+        it 'sets flags for published with file changes' do
+          @resource.file_uploads << FileUpload.create(file_state: 'created', upload_file_name: 'fun.cat', upload_file_size: 666)
+          @resource.reload
+          @resource.curation_activities << CurationActivity.create(status: 'published', user: @user)
+
+          @identifier.reload
+          @resource.reload
+
+          expect(@identifier.pub_state).to eq('published')
+          expect(@resource.meta_view).to eq(true)
+          expect(@resource.file_view).to eq(true)
+        end
+
+        it 'sets flags for withdrawn' do
+          @resource.curation_activities << CurationActivity.create(status: 'withdrawn', user: @user)
+          @identifier.reload
+          @resource.reload
+          expect(@identifier.pub_state).to eq('withdrawn')
+          expect(@resource.meta_view).to eq(false)
+          expect(@resource.file_view).to eq(false)
         end
       end
 

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -653,7 +653,7 @@ module StashEngine
         resources[2].curation_activities << CurationActivity.create(status: 'published', user: @user)
 
         resources[2].file_uploads << FileUpload.create(file_state: 'copied', upload_file_name: 'fun.cat', upload_file_size: 666)
-        resources[2].file_uploads.each{ |fu| fu.update(file_state: 'copied') } # make them all copied, so invalid file history with no one ever adding files
+        resources[2].file_uploads.each { |fu| fu.update(file_state: 'copied') } # make them all copied, so invalid file history
         @identifier.reload
 
         expect(@identifier.borked_file_history?).to eq(true)

--- a/stash_engine/spec/db_spec_helper.rb
+++ b/stash_engine/spec/db_spec_helper.rb
@@ -37,6 +37,16 @@ RSpec.configure do |config|
   config.before(:suite) do
     run_migrations!
 
+    # rubocop:disable Lint/HandleExceptions
+    # had problems in tests with the columns being out of date, but only in a new database such as on Travis, ick. OUr nasty, janky test setup.
+    ActiveRecord::Base.descendants.each do |model|
+      begin
+        model.connection.schema_cache.clear!
+        model.reset_column_information
+      rescue NameError; end
+    end
+    # rubocop:enable Lint/HandleExceptions
+
     DatabaseCleaner.strategy = :deletion
     puts 'Clearing test database'.colorize(:yellow)
     DatabaseCleaner.clean


### PR DESCRIPTION
This is the PR for https://github.com/CDL-Dryad/dryad-product-roadmap/issues/525 .

Essentially, we have flags for a couple things at the resource level and an overall status at the dataset level indicating the current status.  All of this will simplify creating views from overly-complex queries for a standard public view and also allow us to override what is viewed by the public if we wish without having to resort to ugly database hacks like orphaning resources.

Added pub_state to identifier level, which summarizes the status the public sees.

Added meta_view and file_view flags to indicate what resources the public could see.

Embargo is meta_view=true and file_view=false for a resource.  Published=meta_view=true and file_view=true.

We know the latest metadata to display from the last resource with meta_view=true.  We know which file versions to display with file_view=true.

File view is extra nasty because we only want to show versions that have had file changes between one publication and the next.  So if v2 was published and someone played with lots of metadata and v4 was published again with no file changes then only one version of the metadata would appear.  Also only published versions appear so changing files agogo in between infrequent bouts of publishing isn't shown in the UI.

Also extra nasty because we've had to orphan resources so they are disappeared from the UI so versions don't show for the curators currently.  This might mean the versions where we can detect changed files (created, deleted) get disappeared, also.  So if something has negative identifier_id in the resources or files that are only 'copied' from another version, but the files don't exist then we know it's a circus of curatorial database hacks to enjoy.  We'll probably re-fix these eventually, but at least this shouldn't make them disappear from the UI.

Also callbacks get called to update these things upon publishing or on embargoing or upon withdrawing.

Also a bunch of tests and a rake task for updating all these flags when we're about to deploy this.

The version detecting file version changes in callbacks just goes backward to check for changes since the last published version to see if files should be displayed.

Oh, btw, a query to double-check resources and their curation status and all that fun, just change the iden.id in the where clause.

```
SELECT iden.id as identifier_id, iden.identifier, res.id as resource_id, curation.status, res.meta_view, res.file_view
FROM stash_engine_identifiers iden
JOIN stash_engine_resources res
ON iden.id = res.identifier_id
JOIN stash_engine_curation_activities curation
ON res.id = curation.resource_id
JOIN (SELECT max(id) as id FROM stash_engine_curation_activities GROUP BY stash_engine_curation_activities.resource_id) AS terminal_curation_state
ON curation.id = terminal_curation_state.id
AND iden.id = 373;
```