### PR TITLE
Journal published notice

### DIFF
--- a/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -21,20 +21,15 @@ module StashEngine
 
     # Called from CurationActivity when the status is published or embargoed
     def journal_published_notice(resource, status)
-      logger.info('############ journal_published_notice #############')
-      logger.info("status #{status}, config #{APP_CONFIG['send_journal_published_notices']}, notify #{@resource}")
       return unless %w[published embargoed].include?(status)
       return unless APP_CONFIG['send_journal_published_notices']
       assign_variables(resource)
-      logger.info("#### status #{status}, config #{APP_CONFIG['send_journal_published_notices']}, notify #{@resource.identifier.publication_issn}, title #{@resource.title}")
       return unless @resource&.identifier&.journal_notify_contacts&.present?
-      logger.info('############# made it through the gates ############')
-      
 
       mail(to: @resource&.identifier&.journal_notify_contacts,
            subject: "#{rails_env} Dryad Submission: \"#{@resource.title}\"")
     end
-    
+
     # Called from the LandingController when an update happens
     def orcid_invitation(orcid_invite)
       # need to calculate url here because url helpers work erratically in the mailer template itself

--- a/stash_engine/app/mailers/stash_engine/user_mailer.rb
+++ b/stash_engine/app/mailers/stash_engine/user_mailer.rb
@@ -19,6 +19,22 @@ module StashEngine
            subject: "#{rails_env} Dryad Submission \"#{@resource.title}\"")
     end
 
+    # Called from CurationActivity when the status is published or embargoed
+    def journal_published_notice(resource, status)
+      logger.info('############ journal_published_notice #############')
+      logger.info("status #{status}, config #{APP_CONFIG['send_journal_published_notices']}, notify #{@resource}")
+      return unless %w[published embargoed].include?(status)
+      return unless APP_CONFIG['send_journal_published_notices']
+      assign_variables(resource)
+      logger.info("#### status #{status}, config #{APP_CONFIG['send_journal_published_notices']}, notify #{@resource.identifier.publication_issn}, title #{@resource.title}")
+      return unless @resource&.identifier&.journal_notify_contacts&.present?
+      logger.info('############# made it through the gates ############')
+      
+
+      mail(to: @resource&.identifier&.journal_notify_contacts,
+           subject: "#{rails_env} Dryad Submission: \"#{@resource.title}\"")
+    end
+    
     # Called from the LandingController when an update happens
     def orcid_invitation(orcid_invite)
       # need to calculate url here because url helpers work erratically in the mailer template itself

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -147,6 +147,7 @@ module StashEngine
     # Triggered on a status of :published or :embargoed
     def email_author
       StashEngine::UserMailer.status_change(resource, status).deliver_now
+      StashEngine::UserMailer.journal_published_notice(resource, status).deliver_now
     end
 
     # Triggered on a status of :published

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -147,7 +147,21 @@ module StashEngine
     # Triggered on a status of :published or :embargoed
     def email_author
       StashEngine::UserMailer.status_change(resource, status).deliver_now
-      StashEngine::UserMailer.journal_published_notice(resource, status).deliver_now
+      StashEngine::UserMailer.journal_published_notice(resource, status).deliver_now unless previously_published?
+    end
+
+    def previously_published?
+      # ignoring the current CA, is there an embargoed or published status at any point for this identifier?
+      prev_pub = false
+      resource.identifier.resources.each do |res|
+        res.curation_activities.each do |ca|
+          if (ca.id != id) && %w[published embargoed].include?(ca.status)
+            prev_pub = true
+            break
+          end
+        end
+      end
+      prev_pub
     end
 
     # Triggered on a status of :published

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -225,6 +225,10 @@ module StashEngine
       internal_data.find_by(data_type: 'publicationISSN')&.value
     end
 
+    def manuscript_number
+      internal_data.find_by(data_type: 'manuscriptNumber')&.value
+    end      
+    
     def publication_name
       publication_data('fullName')
     end
@@ -240,6 +244,10 @@ module StashEngine
       publication_data('stripeCustomerID')
     end
 
+    def journal_notify_contacts
+      publication_data('notifyContacts')
+    end
+    
     def allow_review?
       publication_data('allowReviewWorkflow') || publication_name.blank?
     end

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -229,6 +229,16 @@ module StashEngine
       internal_data.find_by(data_type: 'manuscriptNumber')&.value
     end
 
+    def publication_article_doi
+      doi = nil
+      resources.each do |res|
+        dois = res.related_identifiers&.select { |id| id.related_identifier_type == 'doi' && id.relation_type == 'issupplementto' }
+        doi = dois&.first&.related_identifier
+        break unless doi.nil?
+      end
+      doi
+    end
+
     def publication_name
       publication_data('fullName')
     end

--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -227,8 +227,8 @@ module StashEngine
 
     def manuscript_number
       internal_data.find_by(data_type: 'manuscriptNumber')&.value
-    end      
-    
+    end
+
     def publication_name
       publication_data('fullName')
     end
@@ -247,7 +247,7 @@ module StashEngine
     def journal_notify_contacts
       publication_data('notifyContacts')
     end
-    
+
     def allow_review?
       publication_data('allowReviewWorkflow') || publication_name.blank?
     end

--- a/stash_engine/app/views/stash_engine/user_mailer/journal_published_notice.html.erb
+++ b/stash_engine/app/views/stash_engine/user_mailer/journal_published_notice.html.erb
@@ -5,6 +5,7 @@
     Data DOI: <%= @resource.identifier_str %><br/>
     Journal: <%= @resource.identifier.publication_name %><br/>
     Journal manuscript number: <%= @resource.identifier.manuscript_number %><br/>
+    Article DOI: <%= @resource.identifier.publication_article_doi %><br/>
 </p>
 
 <p>We welcome your feedback! Contact us at <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>

--- a/stash_engine/app/views/stash_engine/user_mailer/journal_published_notice.html.erb
+++ b/stash_engine/app/views/stash_engine/user_mailer/journal_published_notice.html.erb
@@ -1,5 +1,5 @@
 
-<p>The dataset "<%= @resource.title %>" has been approved by our curation team.</p>
+<p>The dataset "<%= @resource.title %>" has been approved for publication in Dryad.</p>
 
 <p>
     Data DOI: <%= @resource.identifier_str %><br/>

--- a/stash_engine/app/views/stash_engine/user_mailer/journal_published_notice.html.erb
+++ b/stash_engine/app/views/stash_engine/user_mailer/journal_published_notice.html.erb
@@ -1,0 +1,10 @@
+
+<p>The dataset "<%= @resource.title %>" has been approved by our curation team.</p>
+
+<p>
+    Data DOI: <%= @resource.identifier_str %><br/>
+    Journal: <%= @resource.identifier.publication_name %><br/>
+    Journal manuscript number: <%= @resource.identifier.manuscript_number %><br/>
+</p>
+
+<p>We welcome your feedback! Contact us at <a href="mailto:<%= @helpdesk_email %>"><%= @helpdesk_email %></a>.</p>

--- a/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
+++ b/stash_engine/spec/db/stash_engine/curation_activity_spec.rb
@@ -170,6 +170,7 @@ module StashEngine
 
         before(:each) do
           allow_any_instance_of(StashEngine::UserMailer).to receive(:status_change).and_return(true)
+          allow_any_instance_of(StashEngine::UserMailer).to receive(:journal_published_notice).and_return(true)
         end
 
         StashEngine::CurationActivity.statuses.each do |status|
@@ -191,9 +192,7 @@ module StashEngine
           end
 
         end
-
       end
-
       context :email_orcid_invitations do
 
         before(:each) do

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -2,6 +2,7 @@ require 'db_spec_helper'
 require 'webmock/rspec'
 require_relative '../../../../spec_helpers/factory_helper'
 require 'byebug'
+require_relative '../../../../stash_datacite/app/models/stash_datacite/related_identifier.rb'
 
 module StashEngine
 
@@ -30,8 +31,11 @@ module StashEngine
       end
 
       @fake_issn = 'bogus-issn-value'
-      int_datum = InternalDatum.new(identifier_id: @identifier.id, data_type: 'publicationISSN', value: @fake_issn)
-      int_datum.save!
+      int_datum_issn = InternalDatum.new(identifier_id: @identifier.id, data_type: 'publicationISSN', value: @fake_issn)
+      int_datum_issn.save!
+      @fake_manuscript_number = 'bogus-manuscript-number'
+      int_datum_manu = InternalDatum.new(identifier_id: @identifier.id, data_type: 'manuscriptNumber', value: @fake_manuscript_number)
+      int_datum_manu.save!
       @identifier.reload
 
       WebMock.disable_net_connect!
@@ -342,6 +346,22 @@ module StashEngine
     describe '#publication_issn' do
       it 'gets publication_issn through convenience method' do
         expect(@identifier.publication_issn).to eql(@fake_issn)
+      end
+    end
+
+    describe '#manuscript_number' do
+      it 'gets manuscript_number through convenience method' do
+        expect(@identifier.manuscript_number).to eql(@fake_manuscript_number)
+      end
+    end
+
+    describe '#publication_article_doi' do
+      it 'gets publication_article_doi through convenience method' do
+        @fake_article_doi = 'http://doi.org/10.1234/bogus-doi'
+        allow_any_instance_of(Resource).to receive(:related_identifiers).and_return([OpenStruct.new(related_identifier: @fake_article_doi,
+                                                                                                    related_identifier_type: 'doi',
+                                                                                                    relation_type: 'issupplementto')])
+        expect(@identifier.publication_article_doi).to eql(@fake_article_doi)
       end
     end
 

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -2,7 +2,6 @@ require 'db_spec_helper'
 require 'webmock/rspec'
 require_relative '../../../../spec_helpers/factory_helper'
 require 'byebug'
-require_relative '../../../../stash_datacite/app/models/stash_datacite/related_identifier.rb'
 
 module StashEngine
 


### PR DESCRIPTION
PR in stash and dryad-config for CDL-Dryad/dryad-product-roadmap#506

When a dataset is set to status `embargoed` or `published`, email a notice to any associated journal, but only if this is the first time the dataset has been embargoed or published. (We don't want to send multiple notices to the journals when there are new versions or curation weirdness.)



