### PR TITLE
Adding NIH API key for Link out

### DIFF
--- a/stash_engine/lib/stash/link_out/pubmed_sequence_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_sequence_service.rb
@@ -36,7 +36,7 @@ module LinkOut
       return nil unless pmid.present?
       hash = {}
       StashEngine::ExternalReference.sources.each do |db|
-        query = "dbfrom=pubmed&db=#{db}&id=#{pmid}"
+        query = "dbfrom=pubmed&db=#{db}&id=#{pmid}&api_key=#{@ftp.api_key}"
         genbank_ids = extract_genbank_ids(get_xml_from_api(@genbank_api, query))
         hash[db] = genbank_ids unless genbank_ids.empty?
       end

--- a/stash_engine/lib/stash/link_out/pubmed_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_service.rb
@@ -18,12 +18,12 @@ module LinkOut
     attr_reader :links_file
 
     def initialize
-      @pubmed_api = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
-      @pubmed_api_query_prefix = 'db=pubmed&term='
-      @pubmed_api_query_suffix = '[doi]'
-
       @ftp = APP_CONFIG.link_out.pubmed
       @root_url = root_url_ssl
+
+      @pubmed_api = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
+      @pubmed_api_query_prefix = 'db=pubmed&term='
+      @pubmed_api_query_suffix = "[doi]&api_key=#{@ftp.api_key}"
 
       @schema = 'https://www.ncbi.nlm.nih.gov/projects/linkout/doc/LinkOut.dtd'
       @links_file = 'pubmedlinkout.xml'


### PR DESCRIPTION
Added api key to calls to NIH for pubmed and genbank id searches. https://www.ncbi.nlm.nih.gov/books/NBK25497/

Everything seems to be working properly still with the api keys in place when I run the rake seed tasks locally.