### PR TITLE
Link out fix

### DIFF
--- a/stash_engine/lib/stash/link_out/pubmed_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_service.rb
@@ -143,7 +143,7 @@ module LinkOut
     # The PubMed Linkout system though wants it to be unencoded `&` which technically makes the
     # XML document invalid so we need to swap the `&` for `&amp;` after doing our Nokogiri `doc.to_xml`
     def unencode_callback_ampersand(text)
-      text.gsub(/query\=&amp;lo\.doi;/, 'query=2&lo.doi;')
+      text.gsub(/query\=&amp;lo\.doi;/, 'query=&lo.doi;')
     end
 
   end

--- a/stash_engine/lib/stash/link_out/pubmed_service.rb
+++ b/stash_engine/lib/stash/link_out/pubmed_service.rb
@@ -143,7 +143,7 @@ module LinkOut
     # The PubMed Linkout system though wants it to be unencoded `&` which technically makes the
     # XML document invalid so we need to swap the `&` for `&amp;` after doing our Nokogiri `doc.to_xml`
     def unencode_callback_ampersand(text)
-      text.gsub(/query\=%22&amp;lo\.doi;%22/, 'query=%22&lo.doi;%22')
+      text.gsub(/query\=&amp;lo\.doi;/, 'query=2&lo.doi;')
     end
 
   end


### PR DESCRIPTION
Link Out team noted an issue with an ampersand character in one of the files. This was working until we were also asked to remove quote characters from the same section of that file. This caused the `gsub` to no longer properly deal with the ampersand.