### PR TITLE
Fix for asynchronous download while using a sharing link

### DIFF
--- a/stash_engine/app/controllers/stash_engine/downloads_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/downloads_controller.rb
@@ -70,7 +70,7 @@ module StashEngine
     # anymore because of curation so we create a new page to host the form
     def private_async_form
       @share = Share.where(secret_id: params[:secret_id])&.first
-      @resource = @share.resource.identifier&.last_submitted_resource
+      @resource = @share.identifier&.last_submitted_resource
     end
 
     def file_stream

--- a/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/shared_security_controller.rb
@@ -57,7 +57,7 @@ module StashEngine
     end
 
     def admin?(resource:)
-      current_user.present? && (current_user.tenant_id == resource.tenant_id && current_user.role == 'admin')
+      current_user.present? && (current_user&.tenant_id == resource.tenant_id && current_user&.role == 'admin')
     end
 
     def superuser?


### PR DESCRIPTION
We had an error that happens only with large files and a sharing link.  Simple fix and most of this PR is in testing which was a pain, see both stash and dryad repos.

Also minor change to be sure admin? security lookup it handles nils gracefully.  I think it should already, but just in case.