### PR TITLE
Differentiate embargoes for that are dependent or article publication

### DIFF
--- a/stash_engine/app/models/stash_engine/identifier.rb
+++ b/stash_engine/app/models/stash_engine/identifier.rb
@@ -299,6 +299,21 @@ module StashEngine
       my_state
     end
 
+    def embargoed_until_article_appears?
+      return false unless pub_state == 'embargoed'
+
+      found_article_appears = false
+      resources.each do |res|
+        res.curation_activities.each do |ca|
+          next unless ca.status == 'embargoed' && (ca.note&.match('untilArticleAppears') ||
+                                          ca.note&.match('1-year blackout period'))
+          found_article_appears = true
+          break
+        end
+      end
+      found_article_appears
+    end
+
     # returns the publication state based on history
     # finds the latest applicable state from terminal states for each resource/version.
     # We only really care about whether it's some form of published, embargoed or withdrawn

--- a/stash_engine/app/views/stash_engine/landing/_files_embargoed.html.erb
+++ b/stash_engine/app/views/stash_engine/landing/_files_embargoed.html.erb
@@ -1,17 +1,23 @@
 <%# takes local variable of resource %>
 <div class="c-sidebox">
-  <h3 class="c-sidebox__heading">Data Files</h3>
-  <p>
-    This dataset is embargoed <% if @resource.publication_date.present? && @resource.publication_date > Time.new.utc -%>
-      and will be released on <%= formatted_date(@resource.publication_date) %>
-    <% end -%>.
-    <% auth = @resource.authors.first %>
-    <% if auth&.author_email&.present? %>
-      Please contact <a href="mailto:<%= auth.author_email %>"><%= auth.author_standard_name
-      %></a> with any questions.
-    <% else %>
-      <!-- the author sucks and didn't give an email.  Maybe imported data? -->
-    <% end %>
-  </p>
-  <p>Lists of files and downloads will become available to the public when released.</p>
+    <h3 class="c-sidebox__heading">Data Files</h3>
+    <p>
+	<% if @resource.identifier.embargoed_until_article_appears? %>
+	    This dataset is embargoed and will be released when the associated article is published.
+	    Contact <a href="mailto:help@datadryad.org?subject=Article published for <%= @resource.identifier.to_s %>">help@datadryad.org</a>
+	    to notify us of article publication.
+	<% else %>
+	    This dataset is embargoed <% if @resource.publication_date.present? && @resource.publication_date > Time.new.utc -%>
+	    and will be released on <%= formatted_date(@resource.publication_date) %>
+	    <% end -%>.
+	    <% auth = @resource.authors.first %>
+	    <% if auth&.author_email&.present? %>
+		Please contact <a href="mailto:<%= auth.author_email %>"><%= auth.author_standard_name %></a>
+		with any questions.
+	    <% else %>
+		<!-- the author sucks and didn't give an email.  Maybe imported data? -->
+	    <% end %>
+	<% end %>
+    </p>
+    <p>Lists of files and downloads will become available to the public when released.</p>
 </div>

--- a/stash_engine/app/views/stash_engine/user_mailer/embargoed.html.erb
+++ b/stash_engine/app/views/stash_engine/user_mailer/embargoed.html.erb
@@ -3,7 +3,7 @@
 <% if @resource.publication_date.blank? %>
   <p>Your dataset "<%= @resource.title %>" (<%= @resource.identifier_str %>) is now embargoed.</p>
 <% else %>
-  <p>Your dataset "<%= @resource.title %>" (<%= @resource.identifier_str %>) will be embargoed until <%= @resource.publication_date.strftime('%B %d, %Y') %>.</p>
+  <p>Your dataset "<%= @resource.title %>" (<%= @resource.identifier_str %>) will be embargoed until <%= @resource.publication_date.strftime('%B %d, %Y') %><% if @resource.identifier.embargoed_until_article_appears? %>, or until the associated article appears, whichever happens first<% end %>.</p>
 <% end %>
 
 <p>Your DOI has been registered and the landing page for your dataset is publicly available. However, the data files are not viewable or downloadable. <%= 'When your embargo has lifted we will notify you.' if @resource.publication_date.present? %></p>

--- a/stash_engine/app/views/stash_engine/user_mailer/embargoed.html.erb
+++ b/stash_engine/app/views/stash_engine/user_mailer/embargoed.html.erb
@@ -1,7 +1,7 @@
 <p>Dear <%= @user_name %>,</p>
 
 <% if @resource.publication_date.blank? %>
-  <p>Your dataset "<%= @resource.title %>" (<%= @resource.identifier_str %>) is now embargoed.</p>
+  <p>Your dataset "<%= @resource.title %>" (<%= @resource.identifier_str %>) is now embargoed. <% if @resource.identifier.embargoed_until_article_appears? %>The embargo will be released when the associated article is published.<% end %></p>
 <% else %>
   <p>Your dataset "<%= @resource.title %>" (<%= @resource.identifier_str %>) will be embargoed until <%= @resource.publication_date.strftime('%B %d, %Y') %><% if @resource.identifier.embargoed_until_article_appears? %>, or until the associated article appears, whichever happens first<% end %>.</p>
 <% end %>

--- a/stash_engine/spec/db/stash_engine/identifier_spec.rb
+++ b/stash_engine/spec/db/stash_engine/identifier_spec.rb
@@ -552,6 +552,18 @@ module StashEngine
         @identifier.reload
         expect(@identifier.pub_state).to eq('embargoed')
       end
+
+      describe '#embargoed_until_article?' do
+        it 'defaults to not embargoed_until_article' do
+          expect(@identifier.embargoed_until_article_appears?).to be(false)
+        end
+
+        it 'detects embargoed_until_article' do
+          @res3.curation_activities << CurationActivity.create(status: 'embargoed', user: @user,
+                                                               note: 'Adding 1-year blackout period due to journal settings.')
+          expect(@identifier.embargoed_until_article_appears?).to be(true)
+        end
+      end
     end
 
     describe '#fill_resource_view_flags' do

--- a/stash_engine/spec/unit/mailers/user_mailer_spec.rb
+++ b/stash_engine/spec/unit/mailers/user_mailer_spec.rb
@@ -21,6 +21,7 @@ module StashEngine
       allow(@identifier).to receive(:identifier_type).and_return('DOI')
       allow(@identifier).to receive(:publication_issn).and_return(nil)
       allow(@identifier).to receive(:citations).and_return(["https://doi.org/#{@identifier.identifier}"])
+      allow(@identifier).to receive(:embargoed_until_article_appears?).and_return(false)
 
       @tenant = double(Tenant)
       allow(@tenant).to receive(:campus_contacts).and_return(%w[gorgath@example.edu lajuana@example.edu])
@@ -122,6 +123,19 @@ module StashEngine
 
     end
 
+    describe 'embargoed status changes' do
+      it "should send an modified email when embargoed_until_article_appears'" do
+        allow(@resource).to receive(:current_curation_status).and_return('embargoed')
+        allow(@resource).to receive(:publication_date).and_return(Date.today)
+        allow(@identifier).to receive(:embargoed_until_article_appears?).and_return(true)
+
+        UserMailer.status_change(@resource, 'embargoed').deliver_now
+        delivery = assert_email("[test] Dryad Submission \"#{@resource.title}\"")
+        expect(delivery.body.to_s).to include('until the associated article appears')
+      end
+    end
+
+    
     it 'sends an invitation' do
       @invite = double(OrcidInvitation)
       allow(@invite).to receive(:resource).and_return(@resource)

--- a/stash_engine/spec/unit/mailers/user_mailer_spec.rb
+++ b/stash_engine/spec/unit/mailers/user_mailer_spec.rb
@@ -135,7 +135,6 @@ module StashEngine
       end
     end
 
-    
     it 'sends an invitation' do
       @invite = double(OrcidInvitation)
       allow(@invite).to receive(:resource).and_return(@resource)


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/505

When a dataset is put into `embargoed` status, and the curation activities indicate that the embargo is dependent on the publication of an associated article, indicate this in two ways:
- different text on the landing page (where the download links would normally appear)
- additional text in the confirmation email that goes to the submitter