### PR TITLE
Protect against duplicate invoicing

### DIFF
--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -237,6 +237,7 @@ module StashEngine
     # ------------------------------------------
 
     def ready_for_payment?
+      resource&.identifier&.reload
       StashEngine.app&.payments&.service == 'stripe' &&
         resource&.identifier&.invoice_id.nil? &&
         (status == 'published' || status == 'embargoed')


### PR DESCRIPTION
Part of https://github.com/CDL-Dryad/dryad-product-roadmap/issues/545

In some cases, curators were able to issue two invoices for the same item. Ensure the Identifier object is up to date before checking whether it has an invoice_id. 