### PR TITLE
A small change for following more redirects when downloading

### DIFF
--- a/stash_engine/lib/stash/download/base.rb
+++ b/stash_engine/lib/stash/download/base.rb
@@ -35,7 +35,7 @@ module Stash
           # We don't want to hold dead download threads open too long for resource and network reasons.
 
           begin
-            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(7200)
+            http = HTTP.timeout(connect: 30, read: read_timeout).timeout(7200).follow(max_hops: 10)
               .basic_auth(user: tenant.repository.username, pass: tenant.repository.password)
             # .persistent(URI.join(url, '/').to_s)
             merritt_response = http.get(url)


### PR DESCRIPTION
Follow up to 10 redirects because Merritt really likes to give a lot (at least 5 or 6) in some cases and it may cause download to fail for full version.

Critical when using the Merritt UI since it redirects millions of times before giving a download for a version.  I tested this on the server and it works.

I'll re-tag to include this since I discovered it from stage downloads.