### PR TITLE
Keep people from double-deleting the same files

### DIFF
--- a/stash_engine/app/controllers/stash_engine/file_uploads_controller.rb
+++ b/stash_engine/app/controllers/stash_engine/file_uploads_controller.rb
@@ -6,7 +6,6 @@ module StashEngine
   class FileUploadsController < ApplicationController # rubocop:disable Metrics/ClassLength
     before_action :require_login
     before_action :set_file_info, only: %i[destroy destroy_error destroy_manifest]
-    # before_action :require_file_owner, except: %i[create revert validate_urls destroy_error index]
     before_action :ajax_require_modifiable, only: %i[destroy_error destroy_manifest create validate_urls]
     before_action :set_create_prerequisites, only: [:create]
 
@@ -22,7 +21,7 @@ module StashEngine
       end
     end
 
-    # this is a validated manifest URI that doesn't pass validation and we're deleting it from the DB
+    # this seems to destroy a file that had an error?
     def destroy_error
       respond_to do |format|
         format.js do
@@ -36,8 +35,7 @@ module StashEngine
     def destroy_manifest
       respond_to do |format|
         format.js do
-          @file_id = @file.id
-          delete_or_destroy(@file)
+          @file.smart_destroy!
         end
       end
     end
@@ -85,17 +83,6 @@ module StashEngine
       FileUpload.create(validator.upload_attributes_from(translator: url_translator, resource: resource))
     end
 
-    def delete_or_destroy(file)
-      if file.file_state == 'copied'
-        file.file_state = 'deleted'
-        file.save!
-      elsif file.file_state == 'created'
-        temp_file_path = file.temp_file_path
-        File.delete(temp_file_path) if !temp_file_path.blank? && File.exist?(temp_file_path)
-        file.destroy
-      end
-    end
-
     def more_bytes_coming
       File.size(@accum_file) < params[:hidden_bytes].to_i
     end
@@ -113,11 +100,6 @@ module StashEngine
 
     def urls_from(url_param)
       url_param.split(/[\r\n]+/).map(&:strip).delete_if(&:blank?)
-    end
-
-    def require_file_owner
-      return if current_user.id == @file.resource.user_id
-      redirect_to tenants_path
     end
 
     def set_create_prerequisites
@@ -145,8 +127,10 @@ module StashEngine
       File.open(fn, 'ab') { |f| f.write(fileupload.read) }
     end
 
-    # for standard uploads, create standard file in DB before moving on to chunks.
+    # for standard uploads, create standard file in DB, this only happens once a file upload is finished
     def create_db_file(path)
+      # destroy any previous with this name and overwrite with this one
+      @resource.file_uploads.where(upload_file_name: File.basename(path)).destroy_all
       FileUpload.create(
         upload_file_name: File.basename(path),
         temp_file_path: path,
@@ -157,31 +141,6 @@ module StashEngine
         file_state: 'created',
         original_filename: @original_filename || File.basename(path)
       )
-    end
-
-    def correct_existing_for_overwrite(resource_id, file_upload)
-      existing_files = FileUpload
-        .where(resource_id: resource_id)
-        .where(upload_file_name: file_upload.original_filename)
-
-      existing_files.each do |old_f|
-        if old_f.file_state == 'created' || old_f.file_state.blank?
-          delete_original(old_f)
-        elsif old_f.file_state == 'deleted'
-          reset_to_copied(old_f)
-        end
-      end
-    end
-
-    # delete this old file before overwriting with this one, there can be only one current with same name
-    def delete_original(original)
-      File.delete(original.temp_file_path) if File.exist?(original.temp_file_path)
-      original.destroy
-    end
-
-    # set back to 'copied' since this is really just a new version of this old file with same name
-    def reset_to_copied(original)
-      original.update_attribute(:file_state, 'copied')
     end
 
     # Remove any unwanted characters from the uploaded file's name


### PR DESCRIPTION
I'm not sure how they're doing this, but I believe this will keep the deletion filename from appearing more than once.  See https://github.com/CDL-Dryad/dryad-product-roadmap/issues/514

