### PR TITLE
Enforce workflow

### DIFF
--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -85,7 +85,7 @@ module StashApi
       # that is, don't change a status that is already published, embargoed, or curation
       if ca_note&.match(/based on notification from journal/) &&
          %w[published embargoed curation].include?(resource.current_curation_status)
-        ca_note = "received #{ca_status} notification from journal, but retaining current curation status due to workflow rules"
+        ca_note = "received #{ca_status} notification from journal module, but retaining current curation status due to workflow rules"
         ca_status = resource.current_curation_status
       end
 

--- a/stash_api/app/controllers/stash_api/curation_activity_controller.rb
+++ b/stash_api/app/controllers/stash_api/curation_activity_controller.rb
@@ -85,8 +85,8 @@ module StashApi
       # that is, don't change a status that is already published, embargoed, or curation
       if ca_note&.match(/based on notification from journal/) &&
          %w[published embargoed curation].include?(resource.current_curation_status)
+        ca_note = "received #{ca_status} notification from journal, but retaining current curation status due to workflow rules"
         ca_status = resource.current_curation_status
-        ca_note = 'received notification from journal, but retaining current curation status due to workflow rules'
       end
 
       StashEngine::CurationActivity.create(resource_id: resource.id,

--- a/stash_engine/app/models/stash_engine/curation_activity.rb
+++ b/stash_engine/app/models/stash_engine/curation_activity.rb
@@ -49,6 +49,7 @@ module StashEngine
 
     # Callbacks
     # ------------------------------------------
+
     # When the status is published/embargoed send to Stripe and DataCite
     after_create :submit_to_datacite, :update_solr, :submit_to_stripe, :remove_peer_review,
                  if: proc { |ca|

--- a/stash_engine/spec/unit/models/curation_activity_spec.rb
+++ b/stash_engine/spec/unit/models/curation_activity_spec.rb
@@ -148,9 +148,11 @@ module StashEngine
 
       it 'considers changed to be false if the last two curation statuses are equal' do
         @curation_activity1 = create(:curation_activity, status: :embargoed, resource: @resource)
-        @curation_activity2 = create(:curation_activity, status: :embargoed, resource: @resource, note: 'We need more about cats')
+        @curation_activity2 = create(:curation_activity, status: :embargoed, resource: @resource,
+                                                         note: 'We need more about cats')
         expect(@curation_activity2.latest_curation_status_changed?).to be false
       end
     end
+
   end
 end


### PR DESCRIPTION
For https://github.com/CDL-Dryad/dryad-product-roadmap/issues/566

When a curation activity is submitted through the API, if it comes from the journal module, don't let it move the workflow backwards.

I originally tried to add this to the Curation Activity model, for ease of testing, but I couldn't get it to work within the callbacks since it was changing the object.

We don't currently have automated tests that run through the email process. The process for manually testing issues with the email workflow is somewhat convoluted, so I added some documentation about the test process here: http://wiki.datadryad.org/Journal_Metadata_Processing_Technology#Testing_the_end-to-end_Workflow