### PR TITLE
Minor fix for generating file URLs for Merritt Express for the cases …

### DIFF
--- a/stash_engine/app/models/stash_engine/file_upload.rb
+++ b/stash_engine/app/models/stash_engine/file_upload.rb
@@ -84,8 +84,9 @@ module StashEngine
       domain, ark = resource.merritt_protodomain_and_local_id
       # the ark is already encoded in the URLs we are given from sword
       return '' if domain.nil? # if domain is nil then something is wrong with the ARK too, likely
+      # the slash is being double-encoded and normally shouldn't be present, except in a couple of one-off datasets that we regret.
       "#{APP_CONFIG.merritt_express_base_url}/dv/#{resource.stash_version.merritt_version}" \
-          "/#{CGI.unescape(ark)}/#{ERB::Util.url_encode(upload_file_name)}"
+          "/#{CGI.unescape(ark)}/#{ERB::Util.url_encode(upload_file_name).gsub('%252F', '%2F')}"
     end
 
     # makes list of directories with numbers. not modified for > 7 days, and whose corresponding resource has been successfully submitted


### PR DESCRIPTION
…where we have a slash in the filename (like 1 annoying dataset).

I'm replacing the double-encoded slash with a single-encoded slash.  This is pretty much for one dataset.  :-/