### PR TITLE
This allows us to pull Counter CoP stats back from DataCite with 1 week cache

### DIFF
--- a/stash_engine/app/models/stash_engine/counter_stat.rb
+++ b/stash_engine/app/models/stash_engine/counter_stat.rb
@@ -27,12 +27,12 @@ module StashEngine
     # but unfortunately, we can really only display stats against production
     def update_if_necessary
       # we should have a counter stat already if it got to this class
-      # only update stats if it's after the date of the last updated date for record
-      return unless new_record? || updated_at.nil? || Time.new.utc.to_date > updated_at.to_date
-      # update_usage!
-      update_citation_count!
-      self.updated_at = Time.new.utc # seem to need this for some reason
+      # only update stats if it's a later calendar week than this record was updated
+      return unless new_record? || updated_at.nil? || calendar_week(Time.new) > calendar_week(updated_at)
 
+      update_usage!
+      update_citation_count!
+      self.updated_at = Time.new.utc # seem to need this for some reason, since not always updating automatically
       save!
     end
 
@@ -45,6 +45,16 @@ module StashEngine
     def update_citation_count!
       cites = Stash::EventData::Citations.new(doi: identifier.identifier)
       self.citation_count = cites.results.count
+    end
+
+    # This will return the calendar year and week of that year for checking if something has been updated in the last calendar week.
+    # If it is nil or not a time then return week 30 days ago.
+    def calendar_week(time)
+      # %W calculates weeks based on starting Monday and not Sunday, %U is Sunday and %V is ???.
+      # This produces year-week string.
+      return (Time.new - 30.days).strftime('%G-%W') if time.nil? || !time.is_a?(Time)
+
+      time.strftime('%G-%W')
     end
 
   end

--- a/stash_engine/spec/db/stash_engine/counter_stat_spec.rb
+++ b/stash_engine/spec/db/stash_engine/counter_stat_spec.rb
@@ -1,0 +1,59 @@
+require 'db_spec_helper'
+require 'ostruct'
+require 'byebug'
+
+module StashEngine
+
+  describe CounterStat do
+
+    before(:each) do
+      # mock out the stat objects which are used within this class and are unit tested elsewhere
+      allow_any_instance_of(Stash::EventData::Usage).to receive(:unique_dataset_investigations_count).and_return(54)
+      allow_any_instance_of(Stash::EventData::Usage).to receive(:unique_dataset_requests_count).and_return(16)
+      allow_any_instance_of(Stash::EventData::Citations).to receive(:results).and_return({count: 2}.to_ostruct)
+
+      @identifier = Identifier.create(identifier_type: 'DOI', identifier: '10.123/456')
+      @identifier.counter_stat.update(identifier_id: @identifier.id, citation_count: 5, unique_investigation_count: 105,
+                               unique_request_count: 31, updated_at: Time.new - 7.days)
+    end
+
+    describe :check_unique_investigation_count do
+      it 'updates counts if from before this week' do
+        cs = @identifier.counter_stat
+        expect(cs.check_unique_investigation_count).to eq(54)
+      end
+
+      it "doesn't update counts if from this week" do
+        cs = @identifier.counter_stat
+        cs.update(updated_at: Time.new)
+        expect(cs.check_unique_investigation_count).to eq(105)
+      end
+    end
+
+    describe :check_unique_request_count do
+      it 'updates counts if from before this week' do
+        cs = @identifier.counter_stat
+        expect(cs.check_unique_request_count).to eq(16)
+      end
+
+      it "doesn't update counts if from this week" do
+        cs = @identifier.counter_stat
+        cs.update(updated_at: Time.new)
+        expect(cs.check_unique_request_count).to eq(31)
+      end
+    end
+
+    describe :check_citation_count do
+      it 'updates counts if from before this week' do
+        cs = @identifier.counter_stat
+        expect(cs.check_citation_count).to eq(2)
+      end
+
+      it "doesn't update counts if from this week" do
+        cs = @identifier.counter_stat
+        cs.update(updated_at: Time.new)
+        expect(cs.check_citation_count).to eq(5)
+      end
+    end
+  end
+end

--- a/stash_engine/spec/db/stash_engine/counter_stat_spec.rb
+++ b/stash_engine/spec/db/stash_engine/counter_stat_spec.rb
@@ -10,11 +10,11 @@ module StashEngine
       # mock out the stat objects which are used within this class and are unit tested elsewhere
       allow_any_instance_of(Stash::EventData::Usage).to receive(:unique_dataset_investigations_count).and_return(54)
       allow_any_instance_of(Stash::EventData::Usage).to receive(:unique_dataset_requests_count).and_return(16)
-      allow_any_instance_of(Stash::EventData::Citations).to receive(:results).and_return({count: 2}.to_ostruct)
+      allow_any_instance_of(Stash::EventData::Citations).to receive(:results).and_return({ count: 2 }.to_ostruct)
 
       @identifier = Identifier.create(identifier_type: 'DOI', identifier: '10.123/456')
       @identifier.counter_stat.update(identifier_id: @identifier.id, citation_count: 5, unique_investigation_count: 105,
-                               unique_request_count: 31, updated_at: Time.new - 7.days)
+                                      unique_request_count: 31, updated_at: Time.new - 7.days)
     end
 
     describe :check_unique_investigation_count do

--- a/stash_engine/test/models/stash_engine/counter_stat_test.rb
+++ b/stash_engine/test/models/stash_engine/counter_stat_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-module StashEngine
-  class CounterStatTest < ActiveSupport::TestCase
-    # test "the truth" do
-    #   assert true
-    # end
-  end
-end


### PR DESCRIPTION
A PR for part of ticket https://github.com/CDL-Dryad/dryad-product-roadmap/issues/541 .

This gets the stats from DataCite again instead of just out of our database.  Changed caching to do per calendar week.  Added tests that didn't seem to exist for this class yet.